### PR TITLE
Generate unit test information to build unit test target later on

### DIFF
--- a/grazel-gradle-plugin/build.gradle
+++ b/grazel-gradle-plugin/build.gradle
@@ -39,7 +39,6 @@ repositories {
 }
 
 
-
 dependencies {
     implementation platform("org.jetbrains.kotlin:kotlin-bom")
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"

--- a/grazel-gradle-plugin/build.gradle
+++ b/grazel-gradle-plugin/build.gradle
@@ -39,6 +39,7 @@ repositories {
 }
 
 
+
 dependencies {
     implementation platform("org.jetbrains.kotlin:kotlin-bom")
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/di/GrazelComponent.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/di/GrazelComponent.kt
@@ -19,10 +19,10 @@ package com.grab.grazel.di
 import com.google.common.graph.ImmutableValueGraph
 import com.grab.grazel.GrazelExtension
 import com.grab.grazel.di.qualifiers.RootProject
-import com.grab.grazel.gradle.AndroidBuildVariantDataSource
+import com.grab.grazel.gradle.AndroidVariantDataSource
 import com.grab.grazel.gradle.AndroidVariantsExtractor
 import com.grab.grazel.gradle.ConfigurationDataSource
-import com.grab.grazel.gradle.DefaultAndroidBuildVariantDataSource
+import com.grab.grazel.gradle.DefaultAndroidVariantDataSource
 import com.grab.grazel.gradle.DefaultAndroidVariantsExtractor
 import com.grab.grazel.gradle.DefaultConfigurationDataSource
 import com.grab.grazel.gradle.DefaultGradleProjectInfo
@@ -110,8 +110,8 @@ internal object GrazelModule {
 
     @Provides
     @Singleton
-    fun GrazelExtension.provideAndroidBuildVariantDataSource(): AndroidBuildVariantDataSource =
-        DefaultAndroidBuildVariantDataSource(variantFilter = androidConfiguration.variantFilter)
+    fun GrazelExtension.provideAndroidVariantDataSource(): AndroidVariantDataSource =
+        DefaultAndroidVariantDataSource(variantFilter = androidConfiguration.variantFilter)
 
     @Provides
     @Singleton

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/dozer/BazelDependencyAnalytics.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/dozer/BazelDependencyAnalytics.kt
@@ -34,7 +34,7 @@ internal class QueryBazelDependencyAnalytics(
     private val mavenDeps = gradleProjectInfo.projectGraph
         .nodes()
         .asSequence()
-        .flatMap(gradleProjectInfo.dependenciesDataSource::mavenDependencies)
+        .flatMap{ gradleProjectInfo.dependenciesDataSource.mavenDependencies(it) }
         .filter { artifact ->
             !(extension.dependenciesConfiguration.ignoreArtifacts.get()
                 .any { ignore -> "${artifact.group}:${artifact.name}" == ignore })

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/gradle/Project.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/gradle/Project.kt
@@ -129,5 +129,6 @@ private fun canMigrateInternal(
 internal fun Project.getBazelModuleTargets(
     projectDependencyGraph: ImmutableValueGraph<Project, Configuration>
 ) = projectDependencyGraph.successors(this)
+    .filter { projectDependencyGraph.edgeValue(this, it).get().isNotTest() }
     .map { BazelDependency.ProjectDependency(it) }
     .toList()

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/gradle/ProjectDependencyGraphBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/gradle/ProjectDependencyGraphBuilder.kt
@@ -48,7 +48,7 @@ internal class ProjectDependencyGraphBuilder @Inject constructor(
             .asSequence()
             .onEach { projectDependencyGraph.addNode(it) }
             .flatMap { sourceProject ->
-                dependenciesDataSource.projectDependencies(sourceProject)
+                dependenciesDataSource.projectDependencies(sourceProject, ConfigurationScope.TEST)
                     .map { (configuration, projectDependency) ->
                         EdgeData(
                             sourceProject,

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidBinaryDataExtractor.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidBinaryDataExtractor.kt
@@ -21,7 +21,8 @@ import com.grab.grazel.GrazelExtension
 import com.grab.grazel.bazel.rules.DATABINDING_ARTIFACTS
 import com.grab.grazel.bazel.rules.Multidex
 import com.grab.grazel.bazel.starlark.BazelDependency
-import com.grab.grazel.gradle.AndroidBuildVariantDataSource
+import com.grab.grazel.gradle.AndroidVariantDataSource
+import com.grab.grazel.gradle.getMigratableBuildVariants
 import com.grab.grazel.gradle.hasCrashlytics
 import com.grab.grazel.gradle.hasDatabinding
 import com.grab.grazel.gradle.hasGooglePlayServicesPlugin
@@ -38,7 +39,7 @@ internal interface AndroidBinaryDataExtractor {
 
 @Singleton
 internal class DefaultAndroidBinaryDataExtractor @Inject constructor(
-    private val buildVariantDataSource: AndroidBuildVariantDataSource,
+    private val variantDataSource: AndroidVariantDataSource,
     private val grazelExtension: GrazelExtension,
     private val keyStoreExtractor: KeyStoreExtractor,
     private val manifestValuesBuilder: ManifestValuesBuilder
@@ -55,7 +56,7 @@ internal class DefaultAndroidBinaryDataExtractor @Inject constructor(
 
         val googleServicesJson = if (project.hasGooglePlayServicesPlugin) {
             findGoogleServicesJson(
-                variants = buildVariantDataSource.getMigratableVariants(project),
+                variants = variantDataSource.getMigratableBuildVariants(project),
                 project = project
             )
         } else null
@@ -67,7 +68,7 @@ internal class DefaultAndroidBinaryDataExtractor @Inject constructor(
 
         val debugKey = keyStoreExtractor.extract(
             rootProject = project.rootProject,
-            variant = buildVariantDataSource.getMigratableVariants(project).firstOrNull()
+            variant = variantDataSource.getMigratableBuildVariants(project).firstOrNull()
         )
 
 

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidUnitTestDataExtractor.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidUnitTestDataExtractor.kt
@@ -1,0 +1,69 @@
+package com.grab.grazel.migrate.android
+
+import com.android.build.gradle.api.AndroidSourceSet
+import com.google.common.graph.ImmutableValueGraph
+import com.grab.grazel.bazel.starlark.BazelDependency
+import com.grab.grazel.gradle.AndroidVariantDataSource
+import com.grab.grazel.gradle.ConfigurationScope
+import com.grab.grazel.gradle.dependencies.DependenciesDataSource
+import com.grab.grazel.gradle.getMigratableUnitTestVariants
+import com.grab.grazel.migrate.kotlin.kotlinParcelizeDeps
+import com.grab.grazel.migrate.unittest.UnitTestData
+import dagger.Lazy
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+internal const val FORMAT_UNIT_TEST_NAME = "%s-test"
+
+internal interface AndroidUnitTestDataExtractor {
+    fun extract(project: Project): UnitTestData
+}
+
+@Singleton
+internal class DefaultAndroidUnitTestDataExtractor @Inject constructor(
+    private val dependenciesDataSource: DependenciesDataSource,
+    private val variantDataSource: AndroidVariantDataSource,
+    private val dependencyGraphProvider: Lazy<ImmutableValueGraph<Project, Configuration>>
+) : AndroidUnitTestDataExtractor {
+    private val projectDependencyGraph by lazy { dependencyGraphProvider.get() }
+    override fun extract(project: Project): UnitTestData {
+        val migratableSourceSets = variantDataSource
+            .getMigratableUnitTestVariants(project)
+            .asSequence()
+            .flatMap { it.sourceSets.asSequence() }
+            .filterIsInstance<AndroidSourceSet>()
+
+        val srcs = project.unitTestSources(migratableSourceSets).toList()
+
+        val deps = project.getTestBazelModuleTargets(projectDependencyGraph) +
+                dependenciesDataSource.collectMavenDeps(project, ConfigurationScope.TEST) +
+                project.kotlinParcelizeDeps() +
+                BazelDependency.ProjectDependency(project)
+
+        return UnitTestData(
+            name = FORMAT_UNIT_TEST_NAME.format(project.name),
+            srcs = srcs,
+            deps = deps
+        )
+    }
+
+    private fun Project.unitTestSources(
+        sourceSets: Sequence<AndroidSourceSet>,
+        sourceSetType: SourceSetType = SourceSetType.JAVA_KOTLIN
+    ): Sequence<String> {
+        val dirs = sourceSets.flatMap { it.java.srcDirs.asSequence() }
+        val dirsKotlin = dirs.map { File(it.path.replace("/java", "/kotlin")) }
+        return filterValidPaths(dirs + dirsKotlin, sourceSetType.patterns)
+    }
+}
+
+
+internal fun Project.getTestBazelModuleTargets(
+    projectDependencyGraph: ImmutableValueGraph<Project, Configuration>
+) = projectDependencyGraph.successors(this)
+    .map { BazelDependency.ProjectDependency(it) }
+    .toList()
+

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidUnitTestDataExtractor.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidUnitTestDataExtractor.kt
@@ -28,7 +28,8 @@ internal class DefaultAndroidUnitTestDataExtractor @Inject constructor(
     private val variantDataSource: AndroidVariantDataSource,
     private val dependencyGraphProvider: Lazy<ImmutableValueGraph<Project, Configuration>>
 ) : AndroidUnitTestDataExtractor {
-    private val projectDependencyGraph by lazy { dependencyGraphProvider.get() }
+    private val projectDependencyGraph get() =  dependencyGraphProvider.get()
+
     override fun extract(project: Project): UnitTestData {
         val migratableSourceSets = variantDataSource
             .getMigratableUnitTestVariants(project)

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/BuildConfig.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/BuildConfig.kt
@@ -20,7 +20,8 @@ import com.android.build.gradle.BaseExtension
 import com.android.builder.internal.ClassFieldImpl
 import com.android.builder.model.ClassField
 import com.grab.grazel.bazel.starlark.quote
-import com.grab.grazel.gradle.AndroidBuildVariantDataSource
+import com.grab.grazel.gradle.AndroidVariantDataSource
+import com.grab.grazel.gradle.getMigratableBuildVariants
 import com.grab.grazel.gradle.isAndroidApplication
 import org.gradle.api.Project
 
@@ -33,10 +34,10 @@ internal data class BuildConfigData(
 
 internal fun BaseExtension.extractBuildConfig(
     project: Project,
-    androidBuildVariantDataSource: AndroidBuildVariantDataSource
+    androidVariantDataSource: AndroidVariantDataSource
 ): BuildConfigData {
-    val buildConfigFields: Map<String, ClassField> = (androidBuildVariantDataSource
-        .getMigratableVariants(project)
+    val buildConfigFields: Map<String, ClassField> = (androidVariantDataSource
+        .getMigratableBuildVariants(project)
         .firstOrNull()?.buildType?.buildConfigFields
         ?: emptyMap()) +
             defaultConfig.buildConfigFields.toMap() +

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/ManifestValuesBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/ManifestValuesBuilder.kt
@@ -19,8 +19,9 @@ package com.grab.grazel.migrate.android
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.internal.dsl.DefaultConfig
 import com.google.common.graph.ImmutableValueGraph
-import com.grab.grazel.gradle.AndroidBuildVariantDataSource
+import com.grab.grazel.gradle.AndroidVariantDataSource
 import com.grab.grazel.gradle.dependenciesSubGraph
+import com.grab.grazel.gradle.getMigratableBuildVariants
 import com.grab.grazel.gradle.isAndroid
 import dagger.Lazy
 import org.gradle.api.Project
@@ -34,7 +35,7 @@ internal interface ManifestValuesBuilder {
 
 internal class DefaultManifestValuesBuilder @Inject constructor(
     private val dependencyGraphProvider: Lazy<ImmutableValueGraph<Project, Configuration>>,
-    private val buildVariantDataSource: AndroidBuildVariantDataSource
+    private val variantDataSource: AndroidVariantDataSource
 ) : ManifestValuesBuilder {
     private val projectDependencyGraph get() = dependencyGraphProvider.get()
     override fun build(
@@ -54,8 +55,8 @@ internal class DefaultManifestValuesBuilder @Inject constructor(
                     .mapValues { it.value.toString() }
                     .map { it.key to it.value }
 
-                val migratableVariants = buildVariantDataSource
-                    .getMigratableVariants(depProject)
+                val migratableVariants = variantDataSource
+                    .getMigratableBuildVariants(depProject)
                     .asSequence()
 
                 val buildTypePlaceholders = migratableVariants

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/AndroidLibTargetBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/AndroidLibTargetBuilder.kt
@@ -24,6 +24,8 @@ import com.grab.grazel.migrate.TargetBuilder
 import com.grab.grazel.migrate.android.AndroidLibraryData
 import com.grab.grazel.migrate.android.AndroidLibraryDataExtractor
 import com.grab.grazel.migrate.android.AndroidLibraryTarget
+import com.grab.grazel.migrate.android.AndroidUnitTestDataExtractor
+import com.grab.grazel.migrate.unittest.toUnitTestTarget
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoSet
@@ -40,13 +42,16 @@ internal interface AndroidLibTargetBuilderModule {
 
 @Singleton
 internal class AndroidLibTargetBuilder @Inject constructor(
-    private val projectDataExtractor: AndroidLibraryDataExtractor
+    private val projectDataExtractor: AndroidLibraryDataExtractor,
+    private val unitTestDataExtractor: AndroidUnitTestDataExtractor
 ) : TargetBuilder {
 
     override fun build(project: Project): List<BazelTarget> {
-        return listOf(projectDataExtractor.extract(project).toAndroidLibTarget())
+        return listOf(
+            projectDataExtractor.extract(project).toAndroidLibTarget(),
+            unitTestDataExtractor.extract(project).toUnitTestTarget()
+        )
     }
-
 
     override fun canHandle(project: Project): Boolean = with(project) {
         isAndroid && !isKotlin && !isAndroidApplication

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/KtAndroidLibTargetBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/KtAndroidLibTargetBuilder.kt
@@ -29,13 +29,16 @@ import com.grab.grazel.migrate.android.AndroidLibraryData
 import com.grab.grazel.migrate.android.AndroidLibraryDataExtractor
 import com.grab.grazel.migrate.android.AndroidLibraryTarget
 import com.grab.grazel.migrate.android.AndroidManifestParser
+import com.grab.grazel.migrate.android.AndroidUnitTestDataExtractor
 import com.grab.grazel.migrate.android.BuildConfigTarget
 import com.grab.grazel.migrate.android.DefaultAndroidLibraryDataExtractor
 import com.grab.grazel.migrate.android.DefaultAndroidManifestParser
+import com.grab.grazel.migrate.android.DefaultAndroidUnitTestDataExtractor
 import com.grab.grazel.migrate.android.ResValueTarget
 import com.grab.grazel.migrate.android.SourceSetType
 import com.grab.grazel.migrate.kotlin.KtLibraryTarget
 import com.grab.grazel.migrate.toBazelDependency
+import com.grab.grazel.migrate.unittest.toUnitTestTarget
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoSet
@@ -53,6 +56,10 @@ internal interface KtAndroidLibTargetBuilderModule {
     fun DefaultAndroidLibraryDataExtractor.bindAndroidLibraryDataExtractor(): AndroidLibraryDataExtractor
 
     @Binds
+    fun DefaultAndroidUnitTestDataExtractor.bindAndroidUnitTestDataExtractor(): AndroidUnitTestDataExtractor
+
+
+    @Binds
     @IntoSet
     fun KtAndroidLibTargetBuilder.bindKtLibTargetBuilder(): TargetBuilder
 }
@@ -61,6 +68,7 @@ internal interface KtAndroidLibTargetBuilderModule {
 @Singleton
 internal class KtAndroidLibTargetBuilder @Inject constructor(
     private val projectDataExtractor: AndroidLibraryDataExtractor,
+    private val unitTestDataExtractor: AndroidUnitTestDataExtractor,
     private val kotlinConfiguration: KotlinConfiguration
 ) : TargetBuilder {
 
@@ -85,6 +93,8 @@ internal class KtAndroidLibTargetBuilder @Inject constructor(
                 .copy(deps = deps)
                 .toKtLibraryTarget(kotlinConfiguration.enabledTransitiveReduction)
                 ?.also { add(it) }
+
+            add(unitTestDataExtractor.extract(project).toUnitTestTarget())
         }
     }
 

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/KotlinProjectDataExtractor.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/KotlinProjectDataExtractor.kt
@@ -47,7 +47,7 @@ internal class DefaultKotlinProjectDataExtractor @Inject constructor(
     private val dependencyGraphProvider: Lazy<ImmutableValueGraph<Project, Configuration>>
 ) : KotlinProjectDataExtractor {
 
-    private val projectDependencyGraph by lazy { dependencyGraphProvider.get() }
+    private val projectDependencyGraph get() =  dependencyGraphProvider.get()
 
     override fun extract(project: Project): KotlinProjectData {
         val sourceSets = project.the<KotlinJvmProjectExtension>().sourceSets

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/KotlinUnitTestDataExtractor.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/KotlinUnitTestDataExtractor.kt
@@ -46,7 +46,7 @@ internal class DefaultKotlinUnitTestDataExtractor @Inject constructor(
     private val dependencyGraphProvider: Lazy<ImmutableValueGraph<Project, Configuration>>
 ) : KotlinUnitTestDataExtractor {
 
-    private val projectDependencyGraph by lazy { dependencyGraphProvider.get() }
+    private val projectDependencyGraph get() = dependencyGraphProvider.get()
 
     override fun extract(project: Project): UnitTestData {
         val sourceSets = project.the<KotlinJvmProjectExtension>().sourceSets

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/KotlinUnitTestDataExtractor.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/KotlinUnitTestDataExtractor.kt
@@ -17,14 +17,14 @@
 package com.grab.grazel.migrate.kotlin
 
 import com.google.common.graph.ImmutableValueGraph
-import com.grab.grazel.bazel.rules.KOTLIN_PARCELIZE_TARGET
 import com.grab.grazel.bazel.starlark.BazelDependency
 import com.grab.grazel.gradle.dependencies.DependenciesDataSource
 import com.grab.grazel.gradle.getBazelModuleTargets
-import com.grab.grazel.gradle.hasKotlinAndroidExtensions
+import com.grab.grazel.migrate.android.FORMAT_UNIT_TEST_NAME
 import com.grab.grazel.migrate.android.SourceSetType
 import com.grab.grazel.migrate.android.collectMavenDeps
 import com.grab.grazel.migrate.android.filterValidPaths
+import com.grab.grazel.migrate.unittest.UnitTestData
 import dagger.Lazy
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
@@ -33,66 +33,58 @@ import org.gradle.api.internal.artifacts.dependencies.DefaultSelfResolvingDepend
 import org.gradle.kotlin.dsl.the
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
-import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
 
-internal interface KotlinProjectDataExtractor {
-    fun extract(project: Project): KotlinProjectData
+internal interface KotlinUnitTestDataExtractor {
+    fun extract(project: Project): UnitTestData
 }
 
 @Singleton
-internal class DefaultKotlinProjectDataExtractor @Inject constructor(
+internal class DefaultKotlinUnitTestDataExtractor @Inject constructor(
     private val dependenciesDataSource: DependenciesDataSource,
     private val dependencyGraphProvider: Lazy<ImmutableValueGraph<Project, Configuration>>
-) : KotlinProjectDataExtractor {
+) : KotlinUnitTestDataExtractor {
 
     private val projectDependencyGraph by lazy { dependencyGraphProvider.get() }
 
-    override fun extract(project: Project): KotlinProjectData {
+    override fun extract(project: Project): UnitTestData {
         val sourceSets = project.the<KotlinJvmProjectExtension>().sourceSets
-        val srcs = project.kotlinSources(sourceSets, SourceSetType.JAVA_KOTLIN).toList()
-        val resources = project.kotlinSources(sourceSets, SourceSetType.RESOURCES).toList()
+
+        val srcs = project.kotlinTestSources(sourceSets).toList()
 
         val deps = project.getBazelModuleTargets(projectDependencyGraph) +
                 dependenciesDataSource.collectMavenDeps(project) +
                 project.androidJarDeps() +
-                project.kotlinParcelizeDeps()
+                project.kotlinParcelizeDeps() +
+                BazelDependency.ProjectDependency(project)
 
-        return KotlinProjectData(
-            name = project.name,
+        return UnitTestData(
+            name = FORMAT_UNIT_TEST_NAME.format(project.name),
             srcs = srcs,
-            res = resources,
             deps = deps
         )
     }
 
-    private fun Project.kotlinSources(
-        sourceSets: NamedDomainObjectContainer<KotlinSourceSet>,
-        sourceSetType: SourceSetType
+    private fun Project.kotlinTestSources(
+        sourceSets: NamedDomainObjectContainer<KotlinSourceSet>
     ): Sequence<String> {
-        val sourceSetChoosers: KotlinSourceSet.() -> Sequence<File> = when (sourceSetType) {
-            SourceSetType.JAVA, SourceSetType.JAVA_KOTLIN, SourceSetType.KOTLIN -> {
-                { kotlin.srcDirs.asSequence() }
-            }
-            SourceSetType.RESOURCES, SourceSetType.RESOURCES_CUSTOM -> {
-                { resources.srcDirs.asSequence() }
-            }
-            SourceSetType.ASSETS -> {
-                { emptySequence() }
-            }
-        }
         val dirs = sourceSets
             .asSequence()
-            .filter { !it.name.toLowerCase().contains("test") } // TODO Consider enabling later.
-            .flatMap(sourceSetChoosers)
-        return filterValidPaths(dirs, sourceSetType.patterns)
+            .filter { it.name.toLowerCase().contains("test") }
+            .flatMap { it.kotlin.srcDirs.asSequence() }
+        return filterValidPaths(dirs, SourceSetType.JAVA_KOTLIN.patterns)
     }
 }
 
-internal fun Project.kotlinParcelizeDeps(): List<BazelDependency.StringDependency> {
-    return when {
-        hasKotlinAndroidExtensions -> listOf(KOTLIN_PARCELIZE_TARGET)
-        else -> emptyList()
+internal fun Project.androidJarDeps(): List<BazelDependency> {
+    return if (configurations.findByName("compileOnly")
+            ?.dependencies
+            ?.filterIsInstance<DefaultSelfResolvingDependency>()
+            ?.any { dep -> dep.files.any { it.name.contains("android.jar") } } == true
+    ) {
+        listOf(BazelDependency.StringDependency("//shared_versions:android_sdk"))
+    } else {
+        emptyList()
     }
 }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/unittest/UnitTestData.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/unittest/UnitTestData.kt
@@ -1,0 +1,17 @@
+package com.grab.grazel.migrate.unittest
+
+import com.grab.grazel.bazel.starlark.BazelDependency
+
+data class UnitTestData(
+    val name: String,
+    val srcs: List<String>,
+    val deps: List<BazelDependency>
+)
+
+internal fun UnitTestData.toUnitTestTarget(): UnitTestTarget {
+    return UnitTestTarget(
+        name = name,
+        srcs = srcs,
+        deps = deps
+    )
+}

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/unittest/UnitTestTarget.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/unittest/UnitTestTarget.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Grabtaxi Holdings PTE LTE (GRAB)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grab.grazel.migrate.unittest
+
+import com.grab.grazel.bazel.rules.Visibility
+import com.grab.grazel.bazel.rules.androidLibrary
+import com.grab.grazel.bazel.starlark.BazelDependency
+import com.grab.grazel.bazel.starlark.statements
+import com.grab.grazel.migrate.BazelBuildTarget
+
+internal data class UnitTestTarget(
+    override val name: String,
+    override val deps: List<BazelDependency>,
+    override val srcs: List<String> = emptyList(),
+    override val visibility: Visibility = Visibility.Public
+) : BazelBuildTarget {
+    override fun statements() = statements {
+        // Todo add unit test statements
+    }
+}
+
+

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/gradle/DefaultAndroidVariantDataSourceTest.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/gradle/DefaultAndroidVariantDataSourceTest.kt
@@ -27,11 +27,11 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class DefaultAndroidBuildVariantDataSourceTest : GrazelPluginTest() {
+class DefaultAndroidVariantDataSourceTest : GrazelPluginTest() {
     private val project = buildProject("App")
     private val extension = GrazelExtension(project)
     private val fakeVariantsExtractor = FakeAndroidVariantsExtractor()
-    private val buildVariantDataSource = DefaultAndroidBuildVariantDataSource(fakeVariantsExtractor)
+    private val buildVariantDataSource = DefaultAndroidVariantDataSource(fakeVariantsExtractor)
 
     @Test
     fun `when config to ignore variant, assert the related flavors also be ignored`() {
@@ -39,7 +39,7 @@ class DefaultAndroidBuildVariantDataSourceTest : GrazelPluginTest() {
         extension.androidConfiguration.variantFilter {
             if (name in ignoreVariants) setIgnore(true)
         }
-        val ignoreFlavors = DefaultAndroidBuildVariantDataSource(
+        val ignoreFlavors = DefaultAndroidVariantDataSource(
             fakeVariantsExtractor,
             extension.androidConfiguration.variantFilter
         ).getIgnoredFlavors(project)
@@ -66,7 +66,7 @@ class DefaultAndroidBuildVariantDataSourceTest : GrazelPluginTest() {
         extension.androidConfiguration.variantFilter {
             if (name in ignoreVariants) setIgnore(true)
         }
-        DefaultAndroidBuildVariantDataSource(
+        DefaultAndroidVariantDataSource(
             fakeVariantsExtractor,
             extension.androidConfiguration.variantFilter
         ).getIgnoredVariants(project).forEach {
@@ -76,18 +76,19 @@ class DefaultAndroidBuildVariantDataSourceTest : GrazelPluginTest() {
 }
 
 private class FakeAndroidVariantsExtractor : AndroidVariantsExtractor {
-    override fun getVariants(project: Project): Set<BaseVariant> {
-        return setOf(
-            FakeVariant(DEBUG_FLAVOR1, FLAVOR1),
-            FakeVariant(DEBUG_FLAVOR2, FLAVOR2),
-            FakeVariant(RELEASE_FLAVOR1, FLAVOR1),
-            FakeVariant(RELEASE_FLAVOR2, FLAVOR2)
-        )
-    }
+    override fun getVariants(project: Project): Set<BaseVariant> = setOf(
+        FakeVariant(DEBUG_FLAVOR1, FLAVOR1),
+        FakeVariant(DEBUG_FLAVOR2, FLAVOR2),
+        FakeVariant(RELEASE_FLAVOR1, FLAVOR1),
+        FakeVariant(RELEASE_FLAVOR2, FLAVOR2)
+    )
 
-    override fun getFlavors(project: Project): Set<ProductFlavor> {
-        return listOf(FLAVOR1, FLAVOR2).map { FakeProductFlavor(it) }.toSet()
-    }
+    override fun getFlavors(project: Project): Set<ProductFlavor> =
+        listOf(FLAVOR1, FLAVOR2).map { FakeProductFlavor(it) }.toSet()
+
+    override fun getUnitTestVariants(project: Project): Set<BaseVariant> = emptySet()
+
+    override fun getTestVariants(project: Project): Set<BaseVariant> = emptySet()
 }
 
 

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/gradle/DefaultConfigurationDataSourceTest.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/gradle/DefaultConfigurationDataSourceTest.kt
@@ -95,6 +95,49 @@ class DefaultConfigurationDataSourceTest : GrazelPluginTest() {
         assertTrue(configurations.any { it.name.contains(FLAVOR2) })
     }
 
+    @Test
+    fun `configurations should not return test or android tests configuration with build scope`() {
+        val fakeVariantDataSource = FakeAndroidVariantDataSource(listOf(FLAVOR1, FLAVOR2))
+        val configurationDataSource = DefaultConfigurationDataSource(fakeVariantDataSource)
+        val configurations = configurationDataSource.configurations(project, ConfigurationScope.BUILD).toList()
+        assertTrue(configurations.isNotEmpty())
+        configurations.forEach { configuration ->
+            assertTrue(configuration.isNotTest())
+            assertFalse(configuration.isAndroidTest())
+            assertFalse(configuration.isUnitTest())
+        }
+    }
+
+    @Test
+    fun `configurations should return test and build configurations with test scope`() {
+        val fakeVariantDataSource = FakeAndroidVariantDataSource(listOf(FLAVOR1, FLAVOR2))
+        val configurationDataSource = DefaultConfigurationDataSource(fakeVariantDataSource)
+        val configurations = configurationDataSource.configurations(project, ConfigurationScope.TEST).toList()
+        assertTrue(configurations.isNotEmpty())
+        assertTrue { configurations.any { it.isUnitTest() } }
+        configurations.forEach { configuration ->
+            assertTrue(
+                configuration.isNotTest() || configuration.isUnitTest()
+            )
+            assertFalse(configuration.isAndroidTest())
+        }
+    }
+
+    @Test
+    fun `configurations should return android test and build configurations with android test scope`() {
+        val fakeVariantDataSource = FakeAndroidVariantDataSource(listOf(FLAVOR1, FLAVOR2))
+        val configurationDataSource = DefaultConfigurationDataSource(fakeVariantDataSource)
+        val configurations = configurationDataSource.configurations(project, ConfigurationScope.ANDROID_TEST).toList()
+        assertTrue(configurations.isNotEmpty())
+        assertTrue { configurations.any { it.isAndroidTest() } }
+        configurations.forEach { configuration ->
+            assertTrue(
+                configuration.isNotTest() || configuration.isAndroidTest()
+            )
+            assertFalse(configuration.isUnitTest())
+        }
+    }
+
 }
 
 

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/gradle/DefaultConfigurationDataSourceTest.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/gradle/DefaultConfigurationDataSourceTest.kt
@@ -21,7 +21,7 @@ import com.grab.grazel.GrazelPluginTest
 import com.grab.grazel.buildProject
 import com.grab.grazel.util.FLAVOR1
 import com.grab.grazel.util.FLAVOR2
-import com.grab.grazel.util.FakeAndroidBuildVariantDataSource
+import com.grab.grazel.util.FakeAndroidVariantDataSource
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.junit.Before
@@ -82,12 +82,12 @@ class DefaultConfigurationDataSourceTest : GrazelPluginTest() {
     }
 
     private fun createNoFlavorFilterDataSource(): DefaultConfigurationDataSource {
-        return DefaultConfigurationDataSource(FakeAndroidBuildVariantDataSource())
+        return DefaultConfigurationDataSource(FakeAndroidVariantDataSource())
     }
 
     @Test
     fun `when variants filter applied, assert configurations ignore related variants and flavor`() {
-        val fakeVariantDataSource = FakeAndroidBuildVariantDataSource(listOf(FLAVOR1))
+        val fakeVariantDataSource = FakeAndroidVariantDataSource(listOf(FLAVOR1))
         val configurationDataSource = DefaultConfigurationDataSource(fakeVariantDataSource)
         val configurations = configurationDataSource.configurations(project).toList()
         assertTrue(configurations.isNotEmpty())

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/gradle/DefaultDependenciesDataSourceTest.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/gradle/DefaultDependenciesDataSourceTest.kt
@@ -23,7 +23,7 @@ import com.grab.grazel.buildProject
 import com.grab.grazel.gradle.dependencies.*
 import com.grab.grazel.util.FLAVOR1
 import com.grab.grazel.util.FLAVOR2
-import com.grab.grazel.util.FakeAndroidBuildVariantDataSource
+import com.grab.grazel.util.FakeAndroidVariantDataSource
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
@@ -63,7 +63,7 @@ class DefaultDependenciesDataSourceTest : GrazelPluginTest() {
     private lateinit var flavor2Project: Project
     private lateinit var dependenciesDataSource: DefaultDependenciesDataSource
     private lateinit var repositoryDataSource: RepositoryDataSource
-    private lateinit var fakeVariantDataSource: FakeAndroidBuildVariantDataSource
+    private lateinit var fakeVariantDataSource: FakeAndroidVariantDataSource
     private lateinit var configurationDataSource: DefaultConfigurationDataSource
 
     @Before
@@ -74,7 +74,7 @@ class DefaultDependenciesDataSourceTest : GrazelPluginTest() {
         flavor1Project = buildProject(FLAVOR1_PROJECT_NAME, rootProject)
         flavor2Project = buildProject(FLAVOR2_PROJECT_NAME, rootProject)
 
-        fakeVariantDataSource = FakeAndroidBuildVariantDataSource()
+        fakeVariantDataSource = FakeAndroidVariantDataSource()
         configurationDataSource = DefaultConfigurationDataSource(fakeVariantDataSource)
         repositoryDataSource = DefaultRepositoryDataSource(rootProject)
 

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/BuildConfigFieldsTest.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/BuildConfigFieldsTest.kt
@@ -24,8 +24,8 @@ import com.grab.grazel.GrazelExtension.Companion.GRAZEL_EXTENSION
 import com.grab.grazel.GrazelPluginTest
 import com.grab.grazel.buildProject
 import com.grab.grazel.gradle.ANDROID_APPLICATION_PLUGIN
-import com.grab.grazel.gradle.AndroidBuildVariantDataSource
-import com.grab.grazel.gradle.DefaultAndroidBuildVariantDataSource
+import com.grab.grazel.gradle.AndroidVariantDataSource
+import com.grab.grazel.gradle.DefaultAndroidVariantDataSource
 import com.grab.grazel.migrate.android.extractBuildConfig
 import com.grab.grazel.util.doEvaluate
 import org.gradle.api.Project
@@ -37,7 +37,7 @@ import org.junit.Test
 class BuildConfigFieldsTest : GrazelPluginTest() {
     private lateinit var rootProject: Project
     private lateinit var androidBinary: Project
-    private lateinit var androidBuildVariantDataSource: AndroidBuildVariantDataSource
+    private lateinit var androidVariantDataSource: AndroidVariantDataSource
 
     @Before
     fun setUp() {
@@ -45,7 +45,7 @@ class BuildConfigFieldsTest : GrazelPluginTest() {
 
         val grazelGradlePluginExtension = GrazelExtension(rootProject)
         rootProject.extensions.add(GRAZEL_EXTENSION, grazelGradlePluginExtension)
-        androidBuildVariantDataSource = DefaultAndroidBuildVariantDataSource()
+        androidVariantDataSource = DefaultAndroidVariantDataSource()
 
         androidBinary = buildProject("android-binary", rootProject)
         androidBinary.run {
@@ -71,7 +71,7 @@ class BuildConfigFieldsTest : GrazelPluginTest() {
         androidBinary.doEvaluate()
         androidBinary
             .the<BaseExtension>()
-            .extractBuildConfig(androidBinary, androidBuildVariantDataSource)
+            .extractBuildConfig(androidBinary, androidVariantDataSource)
             .let { buildConfigData ->
                 Truth.assertThat(buildConfigData.strings).apply {
                     hasSize(2)

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/android/DefaultManifestValuesBuilderTest.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/android/DefaultManifestValuesBuilderTest.kt
@@ -29,8 +29,8 @@ import com.grab.grazel.GrazelPluginTest
 import com.grab.grazel.buildProject
 import com.grab.grazel.gradle.ANDROID_APPLICATION_PLUGIN
 import com.grab.grazel.gradle.ANDROID_LIBRARY_PLUGIN
-import com.grab.grazel.gradle.AndroidBuildVariantDataSource
-import com.grab.grazel.gradle.DefaultAndroidBuildVariantDataSource
+import com.grab.grazel.gradle.AndroidVariantDataSource
+import com.grab.grazel.gradle.DefaultAndroidVariantDataSource
 import com.grab.grazel.util.doEvaluate
 import dagger.Lazy
 import org.gradle.api.Project
@@ -98,9 +98,9 @@ class DefaultManifestValuesBuilderTest : GrazelPluginTest() {
             putEdgeValue(androidBinary, androidLibrary, configuration)
         }
 
-        val buildVariantDataSource: AndroidBuildVariantDataSource = DefaultAndroidBuildVariantDataSource()
+        val variantDataSource: AndroidVariantDataSource = DefaultAndroidVariantDataSource()
         defaultManifestValuesBuilder =
-            DefaultManifestValuesBuilder(Lazy { ImmutableValueGraph.copyOf(dependencyGraph) }, buildVariantDataSource)
+            DefaultManifestValuesBuilder(Lazy { ImmutableValueGraph.copyOf(dependencyGraph) }, variantDataSource)
     }
 
     @Test

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/util/FakeProductFlavor.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/util/FakeProductFlavor.kt
@@ -23,16 +23,16 @@ import com.android.builder.model.ProductFlavor
 import com.android.builder.model.SigningConfig
 import com.android.builder.model.VectorDrawablesOptions
 import com.grab.grazel.configuration.VariantFilter
-import com.grab.grazel.gradle.AndroidBuildVariantDataSource
+import com.grab.grazel.gradle.AndroidVariantDataSource
 import org.gradle.api.Action
 import org.gradle.api.Project
 import java.io.File
 
-class FakeAndroidBuildVariantDataSource(
+class FakeAndroidVariantDataSource(
     var ignoreFlavorsName: List<String> = emptyList(),
     var ignoreVariantName: List<Pair<String, String?>> = emptyList(),
     override val variantFilter: Action<VariantFilter>? = null
-) : AndroidBuildVariantDataSource {
+) : AndroidVariantDataSource {
     override fun getIgnoredFlavors(project: Project): List<ProductFlavor> =
         ignoreFlavorsName.map { FakeProductFlavor(it) }
 


### PR DESCRIPTION
The PR generates the UnitTestData which will be used to generate the unit test target later on.