### PR TITLE
Add transitive reduction capability for tests via tags

### DIFF
--- a/constants.gradle
+++ b/constants.gradle
@@ -16,7 +16,7 @@
 // TODO migrate to version catalogs
 ext {
     groupId = "com.grab.grazel"
-    versionName = "0.4.0-alpha03"
+    versionName = "0.4.0-alpha04"
 
     kotlinVersion = "1.4.31"
     agpVersion = "4.1.3"

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/extension/TestExtension.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/extension/TestExtension.kt
@@ -50,7 +50,8 @@ class AndroidTestExtension {
 
 data class TestExtension(
     var enableTestMigration: Boolean = false,
-    val androidTest: AndroidTestExtension = AndroidTestExtension()
+    val androidTest: AndroidTestExtension = AndroidTestExtension(),
+    var enabledTransitiveReduction: Boolean = false,
 ) {
 //    fun androidTest(block: AndroidTestExtension.() -> Unit) {
 //        androidTest.block()

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidUnitTestData.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidUnitTestData.kt
@@ -1,6 +1,7 @@
 package com.grab.grazel.migrate.android
 
 import com.grab.grazel.bazel.starlark.BazelDependency
+import com.grab.grazel.migrate.builder.toDirectTranDepTags
 
 data class AndroidUnitTestData(
     val name: String,
@@ -11,7 +12,9 @@ data class AndroidUnitTestData(
     val resources: List<String>,
 )
 
-internal fun AndroidUnitTestData.toUnitTestTarget(): AndroidUnitTestTarget {
+internal fun AndroidUnitTestData.toUnitTestTarget(
+    enabledTransitiveDepsReduction: Boolean = false,
+): AndroidUnitTestTarget {
     return AndroidUnitTestTarget(
         name = name,
         srcs = srcs,
@@ -19,5 +22,10 @@ internal fun AndroidUnitTestData.toUnitTestTarget(): AndroidUnitTestTarget {
         associates = associates,
         customPackage = customPackage,
         resources = resources,
+        tags = if (enabledTransitiveDepsReduction) {
+            deps.toDirectTranDepTags(self = name)
+        } else {
+            emptyList()
+        },
     )
 }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/KtAndroidLibTargetBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/KtAndroidLibTargetBuilder.kt
@@ -92,7 +92,11 @@ internal class KtAndroidLibTargetBuilder @Inject constructor(
                 ?.also { add(it) }
 
             if (testExtension.enableTestMigration)
-                add(unitTestDataExtractor.extract(project).toUnitTestTarget())
+                add(
+                    unitTestDataExtractor
+                        .extract(project)
+                        .toUnitTestTarget(testExtension.enabledTransitiveReduction)
+                )
         }
     }
 

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/KtLibTargetBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/KtLibTargetBuilder.kt
@@ -66,7 +66,7 @@ internal class KtLibTargetBuilder @Inject constructor(
         return if (testExtension.enableTestMigration) {
             listOf(
                 projectData.toKtLibraryTarget(kotlinExtension.enabledTransitiveReduction),
-                unitTestData.toUnitTestTarget()
+                unitTestData.toUnitTestTarget(testExtension.enabledTransitiveReduction)
             )
         } else {
             listOf(projectData.toKtLibraryTarget(kotlinExtension.enabledTransitiveReduction))

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/UnitTestData.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/UnitTestData.kt
@@ -3,6 +3,7 @@ package com.grab.grazel.migrate.kotlin
 import com.grab.grazel.bazel.starlark.BazelDependency
 import com.grab.grazel.migrate.BazelBuildTarget
 import com.grab.grazel.migrate.android.AndroidUnitTestTarget
+import com.grab.grazel.migrate.builder.toDirectTranDepTags
 
 data class UnitTestData(
     val name: String,
@@ -12,7 +13,9 @@ data class UnitTestData(
     val hasAndroidJarDep: Boolean = false,
 )
 
-internal fun UnitTestData.toUnitTestTarget(): BazelBuildTarget =
+internal fun UnitTestData.toUnitTestTarget(
+    enabledTransitiveDepsReduction: Boolean = false,
+): BazelBuildTarget =
     if (hasAndroidJarDep) {
         AndroidUnitTestTarget(
             name = name,
@@ -20,12 +23,22 @@ internal fun UnitTestData.toUnitTestTarget(): BazelBuildTarget =
             deps = deps,
             associates = associates,
             customPackage = "",
+            tags = if (enabledTransitiveDepsReduction) {
+                deps.toDirectTranDepTags(self = name)
+            } else {
+                emptyList()
+            },
         )
     } else {
         UnitTestTarget(
             name = name,
             srcs = srcs,
             deps = deps,
-            associates = associates
+            associates = associates,
+            tags = if (enabledTransitiveDepsReduction) {
+                deps.toDirectTranDepTags(self = name)
+            } else {
+                emptyList()
+            },
         )
     }


### PR DESCRIPTION
## Proposed Changes
The transitive reduction feature was made available for kotlin library builds but not for tests. This change is to make the transitive reduction feature available for grab_android_local_test and kt_jvm_test

## Testing

<!--- Please describe how you tested your changes. -->

## Issues Fixed