### PR TITLE
Use rules_kotlin >= 1.5.0 format changes

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "define_kt_toolchain", "kt_javac_options", "kt_kotlinc_options")
+load("@io_bazel_rules_kotlin//kotlin:core.bzl", "define_kt_toolchain", "kt_javac_options", "kt_kotlinc_options")
 
 kt_kotlinc_options(
     name = "kt_kotlinc_options",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -105,30 +105,24 @@ load("@maven//:defs.bzl", "pinned_maven_install")
 
 pinned_maven_install()
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-git_repository(
+http_archive(
     name = "io_bazel_rules_kotlin",
-    commit = "eae21653baad4b403fee9e8a706c9d4fbd0c27c6",
-    remote = "https://github.com/bazelbuild/rules_kotlin.git",
+    sha256 = "f1a4053eae0ea381147f5056bb51e396c5c494c7f8d50d0dee4cc2f9d5c701b0",
+    url = "https://github.com/bazelbuild/rules_kotlin/releases/download/1.6.0-RC-1/rules_kotlin_release.tgz",
 )
-
-load("@io_bazel_rules_kotlin//kotlin:dependencies.bzl", "kt_download_local_dev_dependencies")
-
-kt_download_local_dev_dependencies()
 
 KOTLIN_VERSION = "1.4.21"
 
 KOTLINC_RELEASE_SHA = "46720991a716e90bfc0cf3f2c81b2bd735c14f4ea6a5064c488e04fd76e6b6c7"
 
-KOTLINC_RELEASE = {
-    "urls": [
-        "https://github.com/JetBrains/kotlin/releases/download/v{v}/kotlin-compiler-{v}.zip".format(v = KOTLIN_VERSION),
-    ],
-    "sha256": KOTLINC_RELEASE_SHA,
-}
+load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories", "kotlinc_version")
 
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories")
+KOTLINC_RELEASE = kotlinc_version(
+    release = KOTLIN_VERSION,
+    sha256 = KOTLINC_RELEASE_SHA,
+)
 
 kotlin_repositories(compiler_release = KOTLINC_RELEASE)
 

--- a/build.gradle
+++ b/build.gradle
@@ -131,9 +131,9 @@ grazel {
             )
         }
         kotlin {
-            gitRepository {
-                commit = "eae21653baad4b403fee9e8a706c9d4fbd0c27c6"
-                remote = "https://github.com/bazelbuild/rules_kotlin.git"
+            httpArchiveRepository {
+                url = "https://github.com/bazelbuild/rules_kotlin/releases/download/1.6.0-RC-1/rules_kotlin_release.tgz"
+                sha256 = "f1a4053eae0ea381147f5056bb51e396c5c494c7f8d50d0dee4cc2f9d5c701b0"
             }
             compiler {
                 version = "1.4.20"

--- a/constants.gradle
+++ b/constants.gradle
@@ -16,7 +16,7 @@
 // TODO migrate to version catalogs
 ext {
     groupId = "com.grab.grazel"
-    versionName = "0.4.0-alpha06"
+    versionName = "0.4.0-alpha07"
 
     kotlinVersion = "1.4.32"
     agpVersion = "7.1.2"

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/KotlinRules.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/KotlinRules.kt
@@ -58,14 +58,18 @@ fun StatementsBuilder.kotlinCompiler(
     KOTLINC_RELEASE_SHA eq kotlinCompilerReleaseSha.quote()
     newLine()
 
-    KOTLINC_RELEASE eq obj {
-        "urls".quote() eq array(
-            """"https://github.com/JetBrains/kotlin/releases/download/v{v}/kotlin-compiler-{v}.zip".format(v = $KOTLIN_VERSION)"""
-        )
-        "sha256".quote() eq KOTLINC_RELEASE_SHA
-    }
+    load(
+        "@io_bazel_rules_kotlin//kotlin:repositories.bzl",
+        "kotlin_repositories",
+        "kotlinc_version"
+    )
 
-    load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories")
+    KOTLINC_RELEASE eq """kotlinc_version(
+        release = $KOTLIN_VERSION,
+        sha256 = $KOTLINC_RELEASE_SHA
+    )
+    """.trimIndent()
+
     add("""kotlin_repositories(compiler_release = $KOTLINC_RELEASE)""")
 }
 
@@ -99,7 +103,7 @@ fun StatementsBuilder.rootKotlinSetup(
         val kotlinCTarget = "kt_kotlinc_options"
         val javaTarget = "kt_javac_options"
         load(
-            "@io_bazel_rules_kotlin//kotlin:kotlin.bzl",
+            "@io_bazel_rules_kotlin//kotlin:core.bzl",
             javaTarget,
             kotlinCTarget,
             "define_kt_toolchain"
@@ -138,7 +142,7 @@ fun StatementsBuilder.loadKtRules(
             "kt_db_android_library"
         )
         isAndroid -> load("@$GRAB_BAZEL_COMMON//tools/kotlin:android.bzl", "kt_android_library")
-        isJvm -> load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+        isJvm -> load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
     }
 }
 

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/extension/KotlinExtension.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/extension/KotlinExtension.kt
@@ -23,8 +23,8 @@ import groovy.lang.Closure
 
 internal const val RULE_KOTLIN_NAME = "io_bazel_rules_kotlin"
 internal const val RULES_KOTLIN_SHA =
-    "da0e6e1543fcc79e93d4d93c3333378f3bd5d29e82c1bc2518de0dbe048e6598"
-internal const val RULES_KOTLIN_VERSION = "legacy-1.4.0-rc3"
+    "12d22a3d9cbcf00f2e2d8f0683ba87d3823cb8c7f6837568dd7e48846e023307"
+internal const val RULES_KOTLIN_VERSION = "v1.5.0"
 
 /**
  * Options for Kotlin Compiler.
@@ -62,7 +62,7 @@ class KotlinToolChain(
 internal val KOTLIN_REPOSITORY = HttpArchiveRule(
     name = RULE_KOTLIN_NAME,
     sha256 = RULES_KOTLIN_SHA,
-    url = """https://github.com/bazelbuild/rules_kotlin/releases/download/%s/rules_kotlin_release.tgz % $RULES_KOTLIN_VERSION"""
+    url = """https://github.com/bazelbuild/rules_kotlin/releases/download/$RULES_KOTLIN_VERSION/rules_kotlin_release.tgz"""
 )
 
 data class KotlinCompiler(

--- a/sample-kotlin-lib/BUILD.bazel
+++ b/sample-kotlin-lib/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 kt_jvm_library(
     name = "sample-kotlin-lib",

--- a/sample-lib-flavor1/BUILD.bazel
+++ b/sample-lib-flavor1/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 kt_jvm_library(
     name = "sample-lib-flavor1",

--- a/sample-lib-flavor2/BUILD.bazel
+++ b/sample-lib-flavor2/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 kt_jvm_library(
     name = "sample-lib-flavor2",


### PR DESCRIPTION
## Proposed Changes
In order to accommodate rules_kotlin 1.5.0 changes, there is a need to change some of the load() statements to point at different .bzl (e.g.  kt_jvm_library would be loaded from jvm.bzl instead of kotlin.bzl).

There is also a helper function (`kotlinc_version`) that was added to help in choosing compiler versions

## Testing

<!--- Please describe how you tested your changes. -->

## Issues Fixed