### PR TITLE
Ignore dynamic-feature modules from dependencies graph

### DIFF
--- a/constants.gradle
+++ b/constants.gradle
@@ -16,7 +16,7 @@
 // TODO migrate to version catalogs
 ext {
     groupId = "com.grab.grazel"
-    versionName = "0.4.0-alpha07"
+    versionName = "0.4.0-alpha08"
 
     kotlinVersion = "1.4.32"
     agpVersion = "7.1.2"

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/gradle/Configuration.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/gradle/Configuration.kt
@@ -69,6 +69,7 @@ internal class DefaultConfigurationDataSource @Inject constructor(
             .filter { !it.name.contains("coreLibraryDesugaring") }
             .filter { !it.name.contains("_internal_aapt2_binary") }
             .filter { !it.name.contains("archives") }
+            .filter { !it.isDynamicConfiguration() } // Remove when Grazel support dynamic-feature plugin
             .filter {
                 when {
                     scopes.isEmpty() -> it.isNotTest() // If the scopes is empty, the build scope will be used by default.
@@ -100,4 +101,5 @@ internal class DefaultConfigurationDataSource @Inject constructor(
 
 internal fun Configuration.isUnitTest() = name.contains("UnitTest", true) || name.startsWith("test")
 internal fun Configuration.isAndroidTest() = name.contains("androidTest", true)
+internal fun Configuration.isDynamicConfiguration() = name.contains("ReverseMetadata", true)
 internal fun Configuration.isNotTest() = !name.contains("test", true)

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/fake/FakeConfiguration.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/fake/FakeConfiguration.kt
@@ -21,7 +21,8 @@ import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.TaskDependency
 import java.io.File
 
-class FakeConfiguration : Configuration {
+class FakeConfiguration(private val name : String = "") : Configuration {
+
     override fun iterator(): MutableIterator<File> {
         TODO("Not yet implemented")
     }
@@ -106,9 +107,7 @@ class FakeConfiguration : Configuration {
         TODO("Not yet implemented")
     }
 
-    override fun getName(): String {
-        TODO("Not yet implemented")
-    }
+    override fun getName(): String = name
 
     override fun isVisible(): Boolean {
         TODO("Not yet implemented")

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/fake/FakeConfigurationContainer.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/fake/FakeConfigurationContainer.kt
@@ -1,0 +1,240 @@
+package com.grab.grazel.fake
+
+import groovy.lang.Closure
+import org.gradle.api.Action
+import org.gradle.api.DomainObjectCollection
+import org.gradle.api.NamedDomainObjectCollectionSchema
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.NamedDomainObjectProvider
+import org.gradle.api.NamedDomainObjectSet
+import org.gradle.api.Namer
+import org.gradle.api.Rule
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.provider.Provider
+import org.gradle.api.specs.Spec
+import java.util.*
+
+class FakeConfigurationContainer(private var configurations: List<Configuration> = emptyList()) :
+    ConfigurationContainer {
+    override fun add(element: Configuration): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun addAll(elements: Collection<Configuration>): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun contains(element: Configuration?): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun containsAll(elements: Collection<Configuration>): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun isEmpty(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun clear() {
+        TODO("Not yet implemented")
+    }
+
+    override fun iterator(): MutableIterator<Configuration> = configurations.toMutableList().iterator()
+
+    override fun remove(element: Configuration?): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun removeAll(elements: Collection<Configuration>): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun retainAll(elements: Collection<Configuration>): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun addLater(p0: Provider<out Configuration>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun addAllLater(p0: Provider<out MutableIterable<Configuration>>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun <S : Configuration?> withType(p0: Class<S>): NamedDomainObjectSet<S> {
+        TODO("Not yet implemented")
+    }
+
+    override fun <S : Configuration?> withType(
+        p0: Class<S>,
+        p1: Action<in S>
+    ): DomainObjectCollection<S> {
+        TODO("Not yet implemented")
+    }
+
+    override fun <S : Configuration?> withType(
+        p0: Class<S>,
+        p1: Closure<*>
+    ): DomainObjectCollection<S> {
+        TODO("Not yet implemented")
+    }
+
+    override fun matching(p0: Spec<in Configuration>): NamedDomainObjectSet<Configuration> {
+        TODO("Not yet implemented")
+    }
+
+    override fun matching(p0: Closure<*>): NamedDomainObjectSet<Configuration> {
+        TODO("Not yet implemented")
+    }
+
+    override fun whenObjectAdded(p0: Action<in Configuration>): Action<in Configuration> {
+        TODO("Not yet implemented")
+    }
+
+    override fun whenObjectAdded(p0: Closure<*>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun whenObjectRemoved(p0: Action<in Configuration>): Action<in Configuration> {
+        TODO("Not yet implemented")
+    }
+
+    override fun whenObjectRemoved(p0: Closure<*>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun all(p0: Action<in Configuration>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun all(p0: Closure<*>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun configureEach(p0: Action<in Configuration>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun findAll(p0: Closure<*>): MutableSet<Configuration> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getNamer(): Namer<Configuration> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAsMap(): SortedMap<String, Configuration> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getNames(): SortedSet<String> {
+        TODO("Not yet implemented")
+    }
+
+    override fun findByName(p0: String): Configuration? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getByName(p0: String): Configuration {
+        TODO("Not yet implemented")
+    }
+
+    override fun getByName(p0: String, p1: Closure<*>): Configuration {
+        TODO("Not yet implemented")
+    }
+
+    override fun getByName(p0: String, p1: Action<in Configuration>): Configuration {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAt(p0: String): Configuration {
+        TODO("Not yet implemented")
+    }
+
+    override fun addRule(p0: Rule): Rule {
+        TODO("Not yet implemented")
+    }
+
+    override fun addRule(p0: String, p1: Closure<*>): Rule {
+        TODO("Not yet implemented")
+    }
+
+    override fun addRule(p0: String, p1: Action<String>): Rule {
+        TODO("Not yet implemented")
+    }
+
+    override fun getRules(): MutableList<Rule> {
+        TODO("Not yet implemented")
+    }
+
+    override fun named(p0: String): NamedDomainObjectProvider<Configuration> {
+        TODO("Not yet implemented")
+    }
+
+    override fun named(
+        p0: String,
+        p1: Action<in Configuration>
+    ): NamedDomainObjectProvider<Configuration> {
+        TODO("Not yet implemented")
+    }
+
+    override fun <S : Configuration?> named(
+        p0: String,
+        p1: Class<S>
+    ): NamedDomainObjectProvider<S> {
+        TODO("Not yet implemented")
+    }
+
+    override fun <S : Configuration?> named(
+        p0: String,
+        p1: Class<S>,
+        p2: Action<in S>
+    ): NamedDomainObjectProvider<S> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getCollectionSchema(): NamedDomainObjectCollectionSchema {
+        TODO("Not yet implemented")
+    }
+
+    override fun configure(p0: Closure<*>): NamedDomainObjectContainer<Configuration> {
+        TODO("Not yet implemented")
+    }
+
+    override fun create(p0: String): Configuration {
+        TODO("Not yet implemented")
+    }
+
+    override fun create(p0: String, p1: Closure<*>): Configuration {
+        TODO("Not yet implemented")
+    }
+
+    override fun create(p0: String, p1: Action<in Configuration>): Configuration {
+        TODO("Not yet implemented")
+    }
+
+    override fun maybeCreate(p0: String): Configuration {
+        TODO("Not yet implemented")
+    }
+
+    override fun register(
+        p0: String,
+        p1: Action<in Configuration>
+    ): NamedDomainObjectProvider<Configuration> {
+        TODO("Not yet implemented")
+    }
+
+    override fun register(p0: String): NamedDomainObjectProvider<Configuration> {
+        TODO("Not yet implemented")
+    }
+
+    override fun detachedConfiguration(vararg p0: Dependency?): Configuration {
+        TODO("Not yet implemented")
+    }
+
+    override val size: Int
+        get() = configurations.size
+}

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/fake/FakeProject.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/fake/FakeProject.kt
@@ -9,6 +9,7 @@ import org.gradle.api.PathValidation
 import org.gradle.api.Project
 import org.gradle.api.ProjectState
 import org.gradle.api.Task
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.dsl.ArtifactHandler
 import org.gradle.api.artifacts.dsl.DependencyHandler
@@ -45,6 +46,7 @@ import java.net.URI
 import java.util.concurrent.Callable
 
 class FakeProject(private val name: String) : Project {
+    var shadowConfigurations : List<Configuration> = emptyList()
 
     override fun toString(): String = name
 
@@ -364,9 +366,8 @@ class FakeProject(private val name: String) : Project {
         TODO("Not yet implemented")
     }
 
-    override fun getConfigurations(): ConfigurationContainer {
-        TODO("Not yet implemented")
-    }
+    override fun getConfigurations(): ConfigurationContainer =
+        FakeConfigurationContainer(shadowConfigurations)
 
     override fun configurations(configureClosure: Closure<*>) {
         TODO("Not yet implemented")

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/gradle/DefaultConfigurationDataSourceTest.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/gradle/DefaultConfigurationDataSourceTest.kt
@@ -22,11 +22,14 @@ import com.grab.grazel.buildProject
 import com.grab.grazel.fake.FLAVOR1
 import com.grab.grazel.fake.FLAVOR2
 import com.grab.grazel.fake.FakeAndroidVariantDataSource
+import com.grab.grazel.fake.FakeConfiguration
+import com.grab.grazel.fake.FakeProject
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 
@@ -52,6 +55,24 @@ class DefaultConfigurationDataSourceTest : GrazelPluginTest() {
                     }
                 }
             }
+    }
+
+    @Test
+    fun `assert configurations filter out dynamic-feature configuration`() {
+        val dynamicFeatureConfigurationName = "debugReverseMetadataValues"
+        val configurationDataSource = createNoFlavorFilterDataSource()
+        val project = FakeProject("project").also {
+            it.shadowConfigurations = listOf(
+                FakeConfiguration("implementation"),
+                FakeConfiguration(dynamicFeatureConfigurationName),
+            )
+        }
+
+        val configurations = configurationDataSource.configurations(project).toList()
+        assertTrue(configurations.isNotEmpty())
+        configurations.forEach {
+            assertNotEquals(dynamicFeatureConfigurationName, it.name)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Proposed Changes
As Grazel hasn't supported dynamic feature delivery. Let's skip these modules/targets from the dependency graph to avoid cycle dependencies errors. 