### PR TITLE
Fix `buildifier` formatting failure on CI

### DIFF
--- a/buildsystem/BUILD.bazel
+++ b/buildsystem/BUILD.bazel
@@ -1,9 +1,10 @@
 filegroup(
-    name = "debug-keystore",
-    srcs = [
-        "debug.keystore",
-    ],
-    visibility = [
-        "//visibility:public",
-    ],
+  name = "debug-keystore",
+  srcs = [
+    "debug.keystore",
+  ],
+  visibility = [
+    "//visibility:public",
+  ]
 )
+

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/starlark/ArrayStatement.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/starlark/ArrayStatement.kt
@@ -24,15 +24,16 @@ open class ArrayStatement(open vararg val elements: Assignee) : Assignee {
         for (element in elements) {
             indent(level + 1, writer)
             element.write(level + 1, writer)
-            writer.write(", \n")
+            writer.write(",\n")
         }
-        indent(level, writer)
+        indent(level + 1, writer)
         writer.print("]")
     }
 }
 
 fun array(vararg elements: Assignee) = ArrayStatement(*elements)
 
-fun array(vararg elements: String) = ArrayStatement(*elements.map { StringStatement(it) }.toTypedArray())
+fun array(vararg elements: String) =
+    ArrayStatement(*elements.map { StringStatement(it) }.toTypedArray())
 
 fun array(list: Collection<String>): ArrayStatement = array(*list.toTypedArray())

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/KeyStoreExtractor.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/KeyStoreExtractor.kt
@@ -57,10 +57,6 @@ class DefaultKeyStoreExtractor @Inject constructor() : KeyStoreExtractor {
                     statements {
                         filegroup(name = targetName, srcs = listOf(storeFile.name))
                     }.writeToFile(keystoreBuildBazel)
-                    // Format it
-                    rootProject.exec {
-                        commandLine = listOf("buildifier", keystoreBuildBazel.absolutePath)
-                    }
                     return "//${rootProject.relativePath(keystoreDir)}:$targetName"
                 }
             }

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/KotlinWorkspaceRulesTest.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/KotlinWorkspaceRulesTest.kt
@@ -21,7 +21,6 @@ import com.grab.grazel.GrazelExtension
 import com.grab.grazel.bazel.starlark.asString
 import com.grab.grazel.buildProject
 import com.grab.grazel.di.DaggerGrazelComponent
-import com.grab.grazel.extension.KotlinCompiler
 import com.grab.grazel.gradle.ANDROID_LIBRARY_PLUGIN
 import com.grab.grazel.gradle.KOTLIN_ANDROID_PLUGIN
 import com.grab.grazel.migrate.internal.WorkspaceBuilder


### PR DESCRIPTION
## Proposed Changes

Keystores files were generated and formatted as part of project buildscript generation. This was incompatible with new buildifier's task based workflow. With this change we simply avoid formatting it and just rely on Kotlin DSL to generate correct syntax.