### PR TITLE
Update `buildifier` tasks to use Property API and task input/output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
             -   name: Bazel Build
                 run: |
-                    ./gradlew bazelBuildAll
+                    ./gradlew bazelBuildAll --stacktrace
 
             -   name: Gradle Build
                 run: |

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ local.properties
 .idea/.gitignore
 .idea/rules_kotlin.iml
 .idea/runConfigurations.xml
+.idea/.name
 .DS_Store
 /build
 /captures

--- a/docs/gradle_tasks.md
+++ b/docs/gradle_tasks.md
@@ -32,7 +32,7 @@ appropriate `buildifier` binary that is used for formatting the bazel scripts.
 ### formatBazelScripts
 
 Depends on `generateBazelScripts` and responsible for formatting the generated file
-with `buildifier`. `formatBuildBazel` and `formatWorkSpace` depends on `generateRootBazelScripts` to
+with `buildifier`. `formatBuildBazel` and `formatWorkSpace` depends on `generateRootBazelScripts` and the buildifier output from `generateBuildifierScript` to
 format root project's Bazel scripts.
 
 ### postScriptGenerateTask

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/FormatBazelBuildFileTask.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/FormatBazelBuildFileTask.kt
@@ -21,6 +21,9 @@ import com.grab.grazel.util.WORKSPACE
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
@@ -39,8 +42,8 @@ abstract class FormatBazelFileTask : DefaultTask() {
     @get:OutputFile
     var bazelFile: File = File(project.projectDir, BUILD_BAZEL)
 
-    @InputFile
-    val buildifierScript: File = File(project.rootProject.buildDir, "buildifier")
+    @get:InputFile
+    abstract val buildifierScript: RegularFileProperty
 
     init {
         outputs.upToDateWhen { false } // This task is supposed to run always until we figure out up-to-date checks
@@ -53,7 +56,7 @@ abstract class FormatBazelFileTask : DefaultTask() {
         if (bazelFile.exists()) {
             execOperations.exec {
                 commandLine = listOf(
-                    buildifierScript.path,
+                    buildifierScript.get().asFile.absolutePath,
                     bazelFile.absolutePath
                 )
             }
@@ -65,11 +68,13 @@ abstract class FormatBazelFileTask : DefaultTask() {
 
         private fun Project.register(
             taskName: String,
+            buildifierScriptProvider: Provider<RegularFile>,
             configureAction: FormatBazelFileTask.() -> Unit
         ): TaskProvider<out Task> {
             return tasks.register<FormatBazelFileTask>(name = taskName).apply {
                 configure {
                     group = GRAZEL_TASK_GROUP
+                    buildifierScript.set(buildifierScriptProvider)
                     configureAction(this)
                 }
             }
@@ -88,30 +93,43 @@ abstract class FormatBazelFileTask : DefaultTask() {
          */
         fun register(
             project: Project,
+            buildifierScriptProvider: Provider<RegularFile>,
             configureAction: Task.() -> Unit
         ): TaskProvider<out Task> {
             val rootProject = project.rootProject
             if (project == rootProject) {
                 // Format work space
-                val formatWorkspace = rootProject.register(FORMAT_WORK_SPACE_FILE_TASK) {
+                val formatWorkspace = rootProject.register(
+                    taskName = FORMAT_WORK_SPACE_FILE_TASK,
+                    buildifierScriptProvider = buildifierScriptProvider,
+                ) {
                     bazelFile = File(rootProject.projectDir, WORKSPACE)
                     description = "Format $WORKSPACE file"
 
                     configureAction(this)
                 }
                 // Format build.bazel
-                val formatBuildBazel = rootProject.register(FORMAT_BUILD_BAZEL_FILE_TASK) {
+                val formatBuildBazel = rootProject.register(
+                    taskName = FORMAT_BUILD_BAZEL_FILE_TASK,
+                    buildifierScriptProvider = buildifierScriptProvider,
+                ) {
                     description = "Format $BUILD_BAZEL file"
 
                     configureAction(this)
                 }
                 // Aggregating task to depend on above
-                return rootProject.register(FORMAT_BAZEL_FILE_TASK) {
+                return rootProject.register(
+                    taskName = FORMAT_BAZEL_FILE_TASK,
+                    buildifierScriptProvider = buildifierScriptProvider,
+                ) {
                     description = TASK_DESCRIPTION
                     dependsOn(formatWorkspace, formatBuildBazel)
                 }
             } else {
-                return project.register(FORMAT_BAZEL_FILE_TASK) {
+                return project.register(
+                    taskName = FORMAT_BAZEL_FILE_TASK,
+                    buildifierScriptProvider = buildifierScriptProvider,
+                ) {
                     description = TASK_DESCRIPTION
                     configureAction(this)
                 }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/FormatBazelBuildFileTask.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/FormatBazelBuildFileTask.kt
@@ -16,6 +16,7 @@
 
 package com.grab.grazel.tasks.internal
 
+import com.grab.grazel.util.BUILDIFIER
 import com.grab.grazel.util.BUILD_BAZEL
 import com.grab.grazel.util.WORKSPACE
 import org.gradle.api.DefaultTask
@@ -68,7 +69,10 @@ abstract class FormatBazelFileTask : DefaultTask() {
 
         private fun Project.register(
             taskName: String,
-            buildifierScriptProvider: Provider<RegularFile>,
+            buildifierScriptProvider: Provider<RegularFile> =
+                objects.fileProperty().convention(
+                    rootProject.layout.buildDirectory.file(BUILDIFIER)
+                ),
             configureAction: FormatBazelFileTask.() -> Unit
         ): TaskProvider<out Task> {
             return tasks.register<FormatBazelFileTask>(name = taskName).apply {
@@ -120,7 +124,6 @@ abstract class FormatBazelFileTask : DefaultTask() {
                 // Aggregating task to depend on above
                 return rootProject.register(
                     taskName = FORMAT_BAZEL_FILE_TASK,
-                    buildifierScriptProvider = buildifierScriptProvider,
                 ) {
                     description = TASK_DESCRIPTION
                     dependsOn(formatWorkspace, formatBuildBazel)

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/GenerateBuildifierScriptTask.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/GenerateBuildifierScriptTask.kt
@@ -17,21 +17,18 @@
 package com.grab.grazel.tasks.internal
 
 import com.grab.grazel.di.qualifiers.RootProject
+import com.grab.grazel.hybrid.bazelCommand
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.register
-import org.gradle.kotlin.dsl.support.serviceOf
-import org.gradle.process.ExecOperations
-import java.io.File
 
 abstract class GenerateBuildifierScriptTask : DefaultTask() {
 
     @get:OutputFile
-    val buildifierScript = File(project.rootProject.buildDir, "buildifier")
-
-    private val execOperations: ExecOperations = project.serviceOf()
+    abstract val buildifierScript: RegularFileProperty
 
     init {
         // This task is supposed to run alawys as the generated buildifier script does not change
@@ -42,18 +39,16 @@ abstract class GenerateBuildifierScriptTask : DefaultTask() {
 
     @TaskAction
     fun action() {
-        execOperations.exec {
-            commandLine = listOf(
-                "bazelisk",
-                "run",
-                "@grab_bazel_common//:buildifier",
-                "--script_path=${buildifierScript.path}"
-            )
-        }
+        project.bazelCommand(
+            "run",
+            "@grab_bazel_common//:buildifier",
+            "--script_path=${buildifierScript.get().asFile.absolutePath}"
+        )
     }
 
     companion object {
         private const val TASK_NAME = "generateBuildifierScript"
+        private const val SCRIPT_NAME = "buildifier"
 
         fun register(
             @RootProject project: Project,
@@ -63,6 +58,7 @@ abstract class GenerateBuildifierScriptTask : DefaultTask() {
         ) {
             description = "Generates buildifier executable script"
             group = GRAZEL_TASK_GROUP
+            buildifierScript.set(project.layout.buildDirectory.file(SCRIPT_NAME))
 
             configureAction(this)
         }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/GenerateBuildifierScriptTask.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/GenerateBuildifierScriptTask.kt
@@ -18,6 +18,7 @@ package com.grab.grazel.tasks.internal
 
 import com.grab.grazel.di.qualifiers.RootProject
 import com.grab.grazel.hybrid.bazelCommand
+import com.grab.grazel.util.BUILDIFIER
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.RegularFileProperty
@@ -48,7 +49,6 @@ abstract class GenerateBuildifierScriptTask : DefaultTask() {
 
     companion object {
         private const val TASK_NAME = "generateBuildifierScript"
-        private const val SCRIPT_NAME = "buildifier"
 
         fun register(
             @RootProject project: Project,
@@ -58,7 +58,7 @@ abstract class GenerateBuildifierScriptTask : DefaultTask() {
         ) {
             description = "Generates buildifier executable script"
             group = GRAZEL_TASK_GROUP
-            buildifierScript.set(project.layout.buildDirectory.file(SCRIPT_NAME))
+            buildifierScript.set(project.layout.buildDirectory.file(BUILDIFIER))
 
             configureAction(this)
         }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/TasksManager.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/TasksManager.kt
@@ -47,13 +47,17 @@ internal class TaskManager @Inject constructor(
      * A <-- B means B depends on A
      *
      * * Root Scripts generation <-- Project level generation
-     * * Root Scripts generation <-- Root formatting
+     * * Root Scripts generation <-- Buildifier Script generation
      * * Project level generation <-- Project level formatting
      * * Project level generation <-- Post script generate task
+     * * Buildifier Script generation <-- Root formatting
+     * * Buildifier Script generation <-- Project level formatting
      * * Root formatting <-- Formatting
      * * Project level formatting <-- Formatting
      * * Formatting <-- Migrate To Bazel
      * * Post script generate task <-- Migrate To Bazel
+     *
+     * See [Task Graph](https://grab.github.io/Grazel/gradle_tasks/#task-graph)
      */
     fun configTasks() {
         // Root bazel file generation task that should run at the start of migration

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/TasksManager.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/TasksManager.kt
@@ -68,9 +68,14 @@ internal class TaskManager @Inject constructor(
             dependsOn(rootGenerateBazelScriptsTasks)
         }
 
+        val buildifierScriptProvider = generateBuildifierScriptTask.flatMap { it.buildifierScript }
+
         // Root formatting task depends on sub project formatting and root generation task
-        val formatBazelFilesTask = FormatBazelFileTask.register(rootProject) {
-            dependsOn(generateBuildifierScriptTask)
+        val formatBazelFilesTask = FormatBazelFileTask.register(
+            project = rootProject,
+            buildifierScriptProvider = buildifierScriptProvider,
+        ) {
+            dependsOn(rootGenerateBazelScriptsTasks)
         }
 
         // Post script generate task must run after scripts are generated
@@ -88,8 +93,11 @@ internal class TaskManager @Inject constructor(
             postScriptGenerateTask.dependsOn(generateBazelScriptsTasks)
 
             // Project level Bazel formatting depends on generation tasks
-            FormatBazelFileTask.register(project) {
-                dependsOn(generateBazelScriptsTasks, generateBuildifierScriptTask)
+            FormatBazelFileTask.register(
+                project = project,
+                buildifierScriptProvider = buildifierScriptProvider,
+            ) {
+                dependsOn(generateBazelScriptsTasks)
             }
         }
 

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/util/Constants.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/util/Constants.kt
@@ -29,3 +29,6 @@ internal const val BAZEL_CLEAN_TASK_NAME = "bazelClean"
 internal const val WORKSPACE = "WORKSPACE"
 internal const val BUILD_BAZEL = "BUILD.bazel"
 internal const val BUILD_BAZEL_IGNORE = "BUILD.bazelignore"
+
+// Buildifier FILE NAME
+internal const val BUILDIFIER = "buildifier"


### PR DESCRIPTION
## Proposed Changes
Adding on to #21, this change improves on the recently added `buildifier` task to use gradle's Property API along side task input/output instead of `dependsOn`
