### PR TITLE
Add a task to generate databinding metadata in bazelrc compatible format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ _sandbox
 
 # Bazel
 bazel-*
+databinding_info.bazelrc
 
 local.bazelrc
 /.idea/libraries-with-intellij-classes.xml

--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,7 @@ grazel {
         }
         features {
             dataBinding = true
+            dataBindingMetaData = true
         }
         ndkApiLevel = 30
     }

--- a/constants.gradle
+++ b/constants.gradle
@@ -16,7 +16,7 @@
 // TODO migrate to version catalogs
 ext {
     groupId = "com.grab.grazel"
-    versionName = "0.4.0-alpha12"
+    versionName = "0.4.0-alpha13"
 
     kotlinVersion = "1.6.10"
     agpVersion = "7.1.2"

--- a/docs/grazel_extension.md
+++ b/docs/grazel_extension.md
@@ -49,6 +49,10 @@ especially for Kotlin. Setting `dataBinding` to `true` will migrate the project 
 Grab's [custom macro](https://github.com/grab/grab-bazel-common/tree/master/tools/databinding).
 See [databinding](databinding.md) for more info.
 
+`dataBindingMetaData` to `true` will generated additional `databinding_info.bazelrc` file in root
+project folder that can be later used by bazel for optimization (Grazel does not ship bazel side
+patches)
+
 ## Dependencies
 
 Grazel uses Gradle's [dependencies](migration_capabilities.md#dependencies) resolution data to

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/di/GrazelComponent.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/di/GrazelComponent.kt
@@ -30,6 +30,7 @@ import com.grab.grazel.gradle.GradleProjectInfo
 import com.grab.grazel.gradle.MigrationChecker
 import com.grab.grazel.gradle.MigrationCriteriaModule
 import com.grab.grazel.gradle.RepositoryDataSource
+import com.grab.grazel.gradle.dependencies.DependenciesDataSource
 import com.grab.grazel.gradle.dependencies.DependenciesGraphsBuilder
 import com.grab.grazel.gradle.dependencies.DependenciesModule
 import com.grab.grazel.gradle.dependencies.DependencyGraphs
@@ -72,6 +73,7 @@ internal interface GrazelComponent {
         fun create(@BindsInstance @RootProject rootProject: Project): GrazelComponent
     }
 
+    fun extension(): GrazelExtension
     fun gradleProjectInfo(): GradleProjectInfo
     fun migrationChecker(): Lazy<MigrationChecker>
     fun progressLogger(): Lazy<ProgressLogger>
@@ -79,6 +81,7 @@ internal interface GrazelComponent {
     fun workspaceBuilderFactory(): Lazy<WorkspaceBuilder.Factory>
     fun rootBazelFileBuilder(): Lazy<RootBazelFileBuilder>
     fun artifactsPinner(): Lazy<ArtifactsPinner>
+    fun dependenciesDataSource(): Lazy<DependenciesDataSource>
 }
 
 @Module(

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/extension/AndroidExtension.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/extension/AndroidExtension.kt
@@ -64,9 +64,26 @@ interface AndroidFeatures {
      * Default `false`
      */
     var dataBinding: Boolean
+
+    /**
+     * Generate a `.bazelrc` compatible metadata file containing metadata about which maven dependencies
+     * use databinding.
+     * Example:
+     * ```
+     * build --android_databinding_package_info=com_grab_grazel=com.grab.grazel
+     * ```
+     *
+     * Needed due to https://github.com/bazelbuild/bazel/issues/13640
+     *
+     * Note: This requires a patch on bazel to ensure the flag is read correctly
+     */
+    var dataBindingMetaData: Boolean
 }
 
-data class DefaultAndroidFeatures(override var dataBinding: Boolean = false) : AndroidFeatures
+data class DefaultAndroidFeatures(
+    override var dataBinding: Boolean = false,
+    override var dataBindingMetaData: Boolean = false
+) : AndroidFeatures
 
 interface VariantFilter {
     fun setIgnore(ignore: Boolean)

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/gradle/Configuration.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/gradle/Configuration.kt
@@ -34,7 +34,6 @@ internal fun GrazelExtension.configurationScopes(): Array<ConfigurationScope> {
     }
 }
 
-
 internal interface ConfigurationDataSource {
     /**
      * Return a sequence of the configurations which are filtered out by the ignore flavors & build variants

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/gradle/dependencies/Dependencies.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/gradle/dependencies/Dependencies.kt
@@ -122,7 +122,8 @@ internal interface DependenciesDataSource {
     fun hasIgnoredArtifacts(project: Project): Boolean
 
     /**
-     * Returns map of [MavenArtifact] and the corresponding artifact file (aar or jar)
+     * Returns map of [MavenArtifact] and the corresponding artifact file (aar or jar). Guarantees the
+     * returned file is downloaded and available on disk
      *
      * @param rootProject The root project instance
      * @param fileExtension The file extension to look for. Use this to reduce the overall number of

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/gradle/dependencies/Dependencies.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/gradle/dependencies/Dependencies.kt
@@ -423,7 +423,10 @@ internal class DefaultDependenciesDataSource @Inject constructor(
             version = version,
             excludeRules = excludeRules
                 .asSequence()
-                .map { ExcludeRule(it.group, it.module) }
+                .map {
+                    @Suppress("USELESS_ELVIS") // Gradle lying, module can be null
+                    ExcludeRule(it.group, it.module ?: "")
+                }
                 .filterNot { it.artifact.isNullOrBlank() }
                 .filterNot { excludeArtifactsDenyList.contains(it.toString()) }
                 .toSet()

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/gradle/dependencies/DependenciesModule.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/gradle/dependencies/DependenciesModule.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 Grabtaxi Holdings PTE LTD (GRAB)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grab.grazel.gradle.dependencies
+
+import com.grab.grazel.GrazelExtension
+import com.grab.grazel.di.qualifiers.RootProject
+import com.grab.grazel.util.GradleProvider
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import org.gradle.api.Project
+import javax.inject.Singleton
+
+@Module(includes = [DependenciesBinder::class])
+internal object DependenciesModule {
+
+    @Provides
+    @Singleton
+    fun GrazelExtension.provideArtifactsConfig(): ArtifactsConfig = toArtifactsConfig()
+
+    @Singleton
+    @Provides
+    fun dependencyResolutionCacheService(
+        @RootProject rootProject: Project
+    ): GradleProvider<@JvmSuppressWildcards DefaultDependencyResolutionService> =
+        DefaultDependencyResolutionService.register(rootProject)
+}
+
+
+@Module
+internal interface DependenciesBinder {
+    @Binds
+    fun DefaultDependenciesDataSource.dependenciesDataSource(): DependenciesDataSource
+}
+
+
+private fun GrazelExtension.toArtifactsConfig() = ArtifactsConfig(
+    excludedList = rules.mavenInstall.excludeArtifacts.get(),
+    ignoredList = dependencies.ignoreArtifacts.get()
+)

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/AndroidDatabindingMetaDataTask.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/AndroidDatabindingMetaDataTask.kt
@@ -19,6 +19,7 @@ package com.grab.grazel.tasks.internal
 import com.grab.grazel.di.GrazelComponent
 import com.grab.grazel.di.qualifiers.RootProject
 import com.grab.grazel.gradle.dependencies.DependenciesDataSource
+import com.grab.grazel.util.ansiGreen
 import dagger.Lazy
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
@@ -56,15 +57,19 @@ constructor(
                 }
                 mavenId to databindingPackage
             }.filter { it.second != null }
+            .sortedBy { it.first }
+            .distinctBy { it.first }
             .joinToString(separator = ",") { "${it.first}=${it.second}" }
 
-        project.rootProject.file("databinding_info.bazelrc")
-            .writeText(
+        project.rootProject.file("databinding_info.bazelrc").apply {
+            writeText(
                 """
             |# Generated file. DO NOT MODIFY.
             |build --android_databinding_package_info=$databindingPackageInfo
             """.trimMargin()
             )
+            logger.quiet("Generated $name".ansiGreen)
+        }
     }
 
     companion object {

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/AndroidDatabindingMetaDataTask.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/AndroidDatabindingMetaDataTask.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 Grabtaxi Holdings PTE LTD (GRAB)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grab.grazel.tasks.internal
+
+import com.grab.grazel.di.GrazelComponent
+import com.grab.grazel.di.qualifiers.RootProject
+import com.grab.grazel.gradle.dependencies.DependenciesDataSource
+import dagger.Lazy
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.register
+import org.jetbrains.kotlin.konan.file.File
+import java.util.zip.ZipFile
+import javax.inject.Inject
+
+internal open class AndroidDatabindingMetaDataTask
+@Inject
+constructor(
+    private val dependenciesDataSource: Lazy<DependenciesDataSource>
+) : DefaultTask() {
+
+    init {
+        outputs.upToDateWhen { false } // Run always until we figure out up to date checks
+    }
+
+    @TaskAction
+    fun action() {
+        val databindingPackageInfo = dependenciesDataSource.get()
+            .dependencyArtifactMap(rootProject = project.rootProject, fileExtension = "aar")
+            .map { (artifact, file) ->
+                val mavenId = listOf(".", "_", ":", "-").fold(artifact.id) { acc, s ->
+                    acc.replace(s, "_")
+                }
+                val databindingPackage = ZipFile(file).use { zip ->
+                    zip.entries()
+                        .asSequence()
+                        .filter { it.name.endsWith(BR_BIN) }
+                        // Databinding package is in the databinding/*-br.bin file
+                        .map { it.name.split(BR_BIN).first().split(File.separator).last() }
+                        .firstOrNull()
+                }
+                mavenId to databindingPackage
+            }.filter { it.second != null }
+            .joinToString(separator = ",") { "${it.first}=${it.second}" }
+
+        project.rootProject.file("databinding_info.bazelrc")
+            .writeText(
+                """
+            |# Generated file. DO NOT MODIFY.
+            |build --android_databinding_package_info=$databindingPackageInfo
+            """.trimMargin()
+            )
+    }
+
+    companion object {
+        private const val TASK_NAME = "generateDatabindingMetaData"
+
+        private const val BR_BIN = "-br.bin"
+
+        fun register(
+            @RootProject rootProject: Project,
+            grazelComponent: GrazelComponent,
+            configureAction: AndroidDatabindingMetaDataTask.() -> Unit = {},
+        ) = rootProject.tasks.register<AndroidDatabindingMetaDataTask>(
+            TASK_NAME,
+            grazelComponent.dependenciesDataSource()
+        ).apply {
+            configure {
+                description = "Generates databinding metadata"
+                group = GRAZEL_TASK_GROUP
+                configureAction(this)
+            }
+        }
+    }
+}

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/TasksManager.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/TasksManager.kt
@@ -115,8 +115,13 @@ internal class TaskManager @Inject constructor(
 
         val migrateTask = migrateToBazelTask().apply {
             dependsOn(formatBazelFilesTask, postScriptGenerateTask)
-            if (grazelComponent.extension().android.features.dataBindingMetaData) {
-                dependsOn(dataBindingMetaDataTask)
+            configure {
+                // Inside a configure block since GrazelExtension won't be configured yet if
+                // we write it as part of plugin application and all extension value would
+                // have default value instead of user configured value.
+                if (grazelComponent.extension().android.features.dataBindingMetaData) {
+                    dependsOn(dataBindingMetaDataTask)
+                }
             }
         }
 

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/TasksManager.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/TasksManager.kt
@@ -48,6 +48,7 @@ internal class TaskManager @Inject constructor(
      *
      * * Root Scripts generation <-- Project level generation
      * * Root Scripts generation <-- Buildifier Script generation
+     * * Root Scripts generation <-- Android data binding metadata generation (if enabled)
      * * Project level generation <-- Project level formatting
      * * Project level generation <-- Post script generate task
      * * Buildifier Script generation <-- Root formatting
@@ -65,6 +66,11 @@ internal class TaskManager @Inject constructor(
             rootProject,
             grazelComponent
         )
+
+        val dataBindingMetaDataTask = AndroidDatabindingMetaDataTask
+            .register(rootProject, grazelComponent) {
+                dependsOn(rootGenerateBazelScriptsTasks)
+            }
 
         val generateBuildifierScriptTask = GenerateBuildifierScriptTask.register(
             rootProject
@@ -109,6 +115,9 @@ internal class TaskManager @Inject constructor(
 
         val migrateTask = migrateToBazelTask().apply {
             dependsOn(formatBazelFilesTask, postScriptGenerateTask)
+            if (grazelComponent.extension().android.features.dataBindingMetaData) {
+                dependsOn(dataBindingMetaDataTask)
+            }
         }
 
         bazelBuildAllTask().dependsOn(migrateTask)

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/gradle/DefaultDependenciesDataSourceTest.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/gradle/DefaultDependenciesDataSourceTest.kt
@@ -276,6 +276,37 @@ class DefaultDependenciesDataSourceTest : GrazelPluginTest() {
         }
     }
 
+    @Test
+    fun `assert dependencyArtifactMap returns artifact and corresponding artifact file`() {
+        setUpDepsWithResolutionStrategy()
+        dependenciesDataSource = DefaultDependenciesDataSource(
+            rootProject = rootProject,
+            configurationDataSource = configurationDataSource,
+            artifactsConfig = ArtifactsConfig(excludedList = listOf()),
+            repositoryDataSource = repositoryDataSource,
+            dependencyResolutionService = DefaultDependencyResolutionService.register(rootProject),
+            grazelExtension = GrazelExtension(rootProject)
+        )
+        val dependencyArtifactMap = dependenciesDataSource.dependencyArtifactMap(
+            rootProject,
+            "aar"
+        )
+        // assert only valid files are returned
+        kotlin.test.assertTrue("Only valid files are returned") {
+            dependencyArtifactMap.values.all {
+                it.extension == "aar" && it.exists()
+            }
+        }
+        // assert valid maven coordinates
+        kotlin.test.assertTrue("Valid maven artifact ids are returned") {
+            listOf(
+                // We expect force version since dependency resolution happens
+                APP_COMPAT.format(APP_COMPAT_FORCE_VERSION),
+                CONSTRAINT_LAYOUT.format(CL_FORCE_VERSION)
+            ).all { dep -> dependencyArtifactMap.keys.map { it.toString() }.contains(dep) }
+        }
+    }
+
 
     private fun setUpFlavorModulesDep() {
         // sub -> flavor1


### PR DESCRIPTION
## Proposed Changes

- Add a task to generate databinding metadata in bazelrc format, this can be later used by bazel to filter out non databinding maven artifacts in the build. Currently bazel just assumes all maven artifacts are databinding enabled
- Above task is disabled by default and can be enabled by `dataBindingMetada` flag

## Testing

- Added for artifact and file calculation

<!--- Please describe how you tested your changes. -->

## Issues Fixed
