### PR TITLE
Add support to version_conflict_policy for maven_install

### DIFF
--- a/constants.gradle
+++ b/constants.gradle
@@ -16,7 +16,7 @@
 // TODO migrate to version catalogs
 ext {
     groupId = "com.grab.grazel"
-    versionName = "0.4.0-alpha13"
+    versionName = "0.4.0-alpha14"
 
     kotlinVersion = "1.6.10"
     agpVersion = "7.1.2"

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/MavenRules.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/MavenRules.kt
@@ -75,7 +75,8 @@ fun StatementsBuilder.mavenInstall(
     failOnMissingChecksum: Boolean = true,
     resolveTimeout: Int = 600,
     excludeArtifacts: List<String> = emptyList(),
-    overrideTargets: Map<String, String> = emptyMap()
+    overrideTargets: Map<String, String> = emptyMap(),
+    versionConflictPolicy: String? = null,
 ) {
     load("@$rulesJvmExternalName//:defs.bzl", "maven_install")
     load("@$rulesJvmExternalName//:specs.bzl", "maven")
@@ -119,6 +120,10 @@ fun StatementsBuilder.mavenInstall(
         }
         mavenInstallJson?.let {
             "maven_install_json" eq mavenInstallJson.quote()
+        }
+
+        versionConflictPolicy?.let {
+            "version_conflict_policy" eq it.quote()
         }
     }
 }
@@ -199,6 +204,7 @@ fun StatementsBuilder.jvmRules(
     jetify: Boolean = false,
     jetifyIncludeList: List<String> = emptyList(),
     failOnMissingChecksum: Boolean = true,
+    versionConflictPolicy: String? = null,
 ) {
     add(rulesJvmExternalRule)
 
@@ -216,7 +222,8 @@ fun StatementsBuilder.jvmRules(
         jetifyIncludeList = jetifyIncludeList,
         failOnMissingChecksum = failOnMissingChecksum,
         resolveTimeout = resolveTimeout,
-        excludeArtifacts = excludeArtifacts
+        excludeArtifacts = excludeArtifacts,
+        versionConflictPolicy = versionConflictPolicy,
     )
 
     if (artifactPinning) {

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/extension/MavenInstallExtension.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/extension/MavenInstallExtension.kt
@@ -64,7 +64,8 @@ data class MavenInstallExtension(
     var overrideTargetLabels: MapProperty<String, String> = objects.mapProperty(),
     var excludeArtifacts: ListProperty<String> = objects.listProperty(),
     var jetifyIncludeList: ListProperty<String> = objects.listProperty(),
-    var jetifyExcludeList: ListProperty<String> = objects.listProperty()
+    var jetifyExcludeList: ListProperty<String> = objects.listProperty(),
+    var versionConflictPolicy: String? = null,
 ) {
     // TODO GitRepositoryRule
     /**

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/internal/WorkspaceBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/internal/WorkspaceBuilder.kt
@@ -184,7 +184,8 @@ internal class WorkspaceBuilder(
             mavenInstallJson = artifactsPinner.mavenInstallJson(),
             resolveTimeout = mavenInstall.resolveTimeout,
             excludeArtifacts = mavenInstall.excludeArtifacts.get(),
-            overrideTargets = mavenInstall.overrideTargetLabels.get()
+            overrideTargets = mavenInstall.overrideTargetLabels.get(),
+            versionConflictPolicy = mavenInstall.versionConflictPolicy,
         )
     }
 


### PR DESCRIPTION
## Proposed Changes
Adding support to add `version_conflict_policy` for `maven_install` so that it can be used to pin dependency versions and resolve version conflicts

See https://github.com/bazelbuild/rules_jvm_external#resolving-user-specified-and-transitive-dependency-version-conflicts
## Testing

<!--- Please describe how you tested your changes. -->

## Issues Fixed