### PR TITLE
Add support to detect source set dirs for tests

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,14 +4,14 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "grab_bazel_common",
-    commit = "1d48088efeb6de455350192e10437abc2c2e0f7a",
+    commit = "d21b8d8a0aba5424cd3f42525b488de14dc47518",
     remote = "https://github.com/grab/grab-bazel-common.git",
 )
 
 load("@grab_bazel_common//:workspace_defs.bzl", "android_tools")
 
 android_tools(
-    commit = "1d48088efeb6de455350192e10437abc2c2e0f7a",
+    commit = "d21b8d8a0aba5424cd3f42525b488de14dc47518",
     remote = "https://github.com/grab/grab-bazel-common.git",
 )
 

--- a/build.gradle
+++ b/build.gradle
@@ -101,10 +101,11 @@ grazel {
     rules {
         test {
             enableTestMigration = true
+            detectSourceSets = true
         }
         bazelCommon {
             gitRepository {
-                commit = "1d48088efeb6de455350192e10437abc2c2e0f7a"
+                commit = "d21b8d8a0aba5424cd3f42525b488de14dc47518"
                 remote = "https://github.com/grab/grab-bazel-common.git"
             }
             toolchains {

--- a/constants.gradle
+++ b/constants.gradle
@@ -16,7 +16,7 @@
 // TODO migrate to version catalogs
 ext {
     groupId = "com.grab.grazel"
-    versionName = "0.4.0-alpha14"
+    versionName = "0.4.0-alpha15"
 
     kotlinVersion = "1.6.10"
     agpVersion = "7.1.2"

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/AndroidRules.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/AndroidRules.kt
@@ -254,6 +254,7 @@ fun StatementsBuilder.grabAndroidLocalTest(
     name: String,
     customPackage: String,
     srcs: List<String> = emptyList(),
+    additionalSrcSets: List<String> = emptyList(),
     srcsGlob: List<String> = emptyList(),
     visibility: Visibility = Visibility.Public,
     deps: List<BazelDependency> = emptyList(),
@@ -269,6 +270,9 @@ fun StatementsBuilder.grabAndroidLocalTest(
         "custom_package" eq customPackage.quote()
         srcs.notEmpty {
             "srcs" eq srcs.map(String::quote)
+        }
+        additionalSrcSets.notEmpty {
+            "additional_src_sets" eq additionalSrcSets.map(String::quote)
         }
         srcsGlob.notEmpty {
             "srcs" eq glob(srcsGlob.map(String::quote))

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/KotlinRules.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/KotlinRules.kt
@@ -227,6 +227,7 @@ fun StatementsBuilder.ktLibrary(
 fun StatementsBuilder.grabKtJvmTest(
     name: String,
     srcs: List<String> = emptyList(),
+    additionalSrcSets: List<String> = emptyList(),
     srcsGlob: List<String> = emptyList(),
     visibility: Visibility = Public,
     associates: List<BazelDependency> = emptyList(),
@@ -243,6 +244,9 @@ fun StatementsBuilder.grabKtJvmTest(
         }
         srcsGlob.notEmpty {
             "srcs" eq glob(srcsGlob.map(String::quote))
+        }
+        additionalSrcSets.notEmpty {
+            "additional_src_sets" eq additionalSrcSets.map(String::quote)
         }
         "visibility" eq array(visibility.rule.quote())
         deps.notEmpty {

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/extension/TestExtension.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/extension/TestExtension.kt
@@ -44,23 +44,9 @@ data class RobolectricExtension(
     }
 }
 
-
-class AndroidTestExtension {
-    // TODO
-}
-
 data class TestExtension(
     var enableTestMigration: Boolean = false,
-    val androidTest: AndroidTestExtension = AndroidTestExtension(),
     var enabledTransitiveReduction: Boolean = false,
-) {
-//    fun androidTest(block: AndroidTestExtension.() -> Unit) {
-//        androidTest.block()
-//    }
-//
-//    fun androidTest(closure: Closure<*>) {
-//        closure.delegate = androidTest
-//        closure.call()
-//    }
-}
+    var detectSourceSets: Boolean = false,
+)
 

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidUnitTestData.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidUnitTestData.kt
@@ -5,6 +5,7 @@ import com.grab.grazel.bazel.starlark.BazelDependency
 data class AndroidUnitTestData(
     val name: String,
     val srcs: List<String>,
+    val additionalSrcSets: List<String>,
     val deps: List<BazelDependency>,
     val tags: List<String>,
     val customPackage: String,
@@ -15,6 +16,7 @@ data class AndroidUnitTestData(
 internal fun AndroidUnitTestData.toUnitTestTarget() = AndroidUnitTestTarget(
     name = name,
     srcs = srcs,
+    additionalSrcSets = additionalSrcSets,
     deps = deps,
     associates = associates,
     customPackage = customPackage,

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidUnitTestDataExtractor.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidUnitTestDataExtractor.kt
@@ -65,6 +65,7 @@ internal class DefaultAndroidUnitTestDataExtractor @Inject constructor(
             .filterIsInstance<AndroidSourceSet>()
 
         val srcs = project.unitTestSources(migratableSourceSets).toList()
+        val additionalSrcSets = project.unitTestNonDefaultSourceSets(migratableSourceSets).toList()
 
         val resources = project.unitTestResources(migratableSourceSets).toList()
 
@@ -83,6 +84,7 @@ internal class DefaultAndroidUnitTestDataExtractor @Inject constructor(
         return AndroidUnitTestData(
             name = name,
             srcs = srcs,
+            additionalSrcSets = additionalSrcSets,
             deps = deps,
             tags = tags,
             customPackage = extractPackageName(project),
@@ -98,6 +100,14 @@ internal class DefaultAndroidUnitTestDataExtractor @Inject constructor(
         val dirs = sourceSets.flatMap { it.java.srcDirs.asSequence() }
         val dirsKotlin = dirs.map { File(it.path.replace("/java", "/kotlin")) }
         return filterSourceSetPaths(dirs + dirsKotlin, sourceSetType.patterns)
+    }
+
+    private fun Project.unitTestNonDefaultSourceSets(
+        sourceSets: Sequence<AndroidSourceSet>,
+    ): Sequence<String> {
+        val dirs = sourceSets.flatMap { it.java.srcDirs.asSequence() }
+        val dirsKotlin = dirs.map { File(it.path.replace("/java", "/kotlin")) }
+        return filterNonDefaultSourceSetDirs(dirs + dirsKotlin)
     }
 
     private fun Project.unitTestResources(

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidUnitTestTarget.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidUnitTestTarget.kt
@@ -31,6 +31,7 @@ internal data class AndroidUnitTestTarget(
     val customPackage: String,
     val tags: List<String> = emptyList(),
     val resources: List<String> = emptyList(),
+    val additionalSrcSets: List<String> = emptyList(),
 ) : BazelBuildTarget {
     override fun statements() = statements {
         if (srcs.isEmpty()) return@statements
@@ -43,6 +44,7 @@ internal data class AndroidUnitTestTarget(
             tags = tags,
             customPackage = customPackage,
             resourcesGlob = resources,
+            additionalSrcSets = additionalSrcSets,
         )
     }
 }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/SourceSet.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/SourceSet.kt
@@ -24,6 +24,9 @@ private const val JAVA_PATTERN = "**/*.java"
 private const val KOTLIN_PATTERN = "**/*.kt"
 private const val ALL_PATTERN = "**"
 
+private const val JAVA_DEFAULT_TEST_DIR = "src/test/java"
+private const val KOTLIN_DEFAULT_TEST_DIR = "src/test/kotlin"
+
 enum class SourceSetType(val patterns: Sequence<String>) {
     JAVA(patterns = sequenceOf(JAVA_PATTERN)),
     JAVA_KOTLIN(patterns = sequenceOf(JAVA_PATTERN, KOTLIN_PATTERN)),
@@ -39,7 +42,7 @@ enum class SourceSetType(val patterns: Sequence<String>) {
  */
 internal fun Project.filterSourceSetPaths(
     dirs: Sequence<File>,
-    patterns: Sequence<String>
+    patterns: Sequence<String>,
 ): Sequence<String> = dirs.filter(File::exists)
     .map(::relativePath)
     .flatMap { dir ->
@@ -59,3 +62,11 @@ internal fun Project.filterSourceSetPaths(
             }
         }
     }.distinct()
+
+internal fun Project.filterNonDefaultSourceSetDirs(
+    dirs: Sequence<File>,
+): Sequence<String> = dirs.filter(File::exists)
+    .map(::relativePath)
+    .filter { dir ->
+        dir != JAVA_DEFAULT_TEST_DIR && dir != KOTLIN_DEFAULT_TEST_DIR
+    }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/UnitTestData.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/UnitTestData.kt
@@ -7,6 +7,7 @@ import com.grab.grazel.migrate.android.AndroidUnitTestTarget
 data class UnitTestData(
     val name: String,
     val srcs: List<String>,
+    val additionalSrcSets: List<String>,
     val deps: List<BazelDependency>,
     val tags: List<String>,
     val associates: List<BazelDependency>,
@@ -18,6 +19,7 @@ internal fun UnitTestData.toUnitTestTarget(): BazelBuildTarget =
         AndroidUnitTestTarget(
             name = name,
             srcs = srcs,
+            additionalSrcSets = additionalSrcSets,
             deps = deps,
             associates = associates,
             customPackage = "",
@@ -27,6 +29,7 @@ internal fun UnitTestData.toUnitTestTarget(): BazelBuildTarget =
         UnitTestTarget(
             name = name,
             srcs = srcs,
+            additionalSrcSets = additionalSrcSets,
             deps = deps,
             associates = associates,
             tags = tags,

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/UnitTestTarget.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/UnitTestTarget.kt
@@ -28,13 +28,15 @@ internal data class UnitTestTarget(
     override val srcs: List<String> = emptyList(),
     override val visibility: Visibility = Visibility.Public,
     val associates: List<BazelDependency> = emptyList(),
-    val tags: List<String> = emptyList()
+    val tags: List<String> = emptyList(),
+    val additionalSrcSets: List<String> = emptyList(),
 ) : BazelBuildTarget {
     override fun statements() = statements {
         if (srcs.isEmpty()) return@statements
         grabKtJvmTest(
             name = name,
             srcsGlob = srcs,
+            additionalSrcSets = additionalSrcSets,
             deps = deps,
             visibility = visibility,
             associates = associates,

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/android/DefaultAndroidUnitTestDataExtractorTest.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/android/DefaultAndroidUnitTestDataExtractorTest.kt
@@ -141,4 +141,25 @@ class DefaultAndroidUnitTestDataExtractorTest : GrazelPluginTest() {
             contains("src/test/resources/**")
         }
     }
+
+    @Test
+    fun `assert additional source sets are extracted correctly`() {
+        val defaultTestSourceSets = listOf("src/test/java", "src/test/kotlin")
+        val additionalTestSourceSets = listOf("src/testDebug/java")
+
+        additionalTestSourceSets.map { sourceSet ->
+            File(subProjectDir, "$sourceSet/Test.kt")
+        }.forEach { file ->
+            file.parentFile.mkdirs()
+            file.createNewFile()
+        }
+
+        subProject.doEvaluate()
+        val androidUnitTestData = defaultAndroidUnitTestDataExtractor.extract(subProject)
+
+        Truth.assertThat(androidUnitTestData.additionalSrcSets).apply {
+            containsExactlyElementsIn(additionalTestSourceSets)
+            containsNoneIn(defaultTestSourceSets)
+        }
+    }
 }


### PR DESCRIPTION
## Proposed Changes
Adding support for the new change in [`grab-bazel-common`](https://github.com/grab/grab-bazel-common/commit/d21b8d8a0aba5424cd3f42525b488de14dc47518) that allows for declaring `additional_src_sets` to detect tests for execution

## Testing

<!--- Please describe how you tested your changes. -->

## Issues Fixed