### PR TITLE
Decouple CrashlyticsTarget from AndroidBinaryTarget

### DIFF
--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/GoogleServicesRules.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/GoogleServicesRules.kt
@@ -55,16 +55,19 @@ internal const val GOOGLE_SERVICES_XML = "GOOGLE_SERVICES_XML"
  *     google_services.xml
  */
 fun StatementsBuilder.googleServicesXml(
-    packageName: String,
-    googleServicesJson: String
+    packageName: String?,
+    googleServicesJson: String?,
 ): Assignee {
-    load("@tools_android//tools/googleservices:defs.bzl", "google_services_xml")
-    GOOGLE_SERVICES_XML eq Assignee { // Create new statements scope to not add to current scope
-        function("google_services_xml") {
-            "package_name" eq packageName.quote()
-            "google_services_json" eq googleServicesJson.quote()
+    if (!packageName.isNullOrBlank() && !googleServicesJson.isNullOrBlank()) {
+        load("@tools_android//tools/googleservices:defs.bzl", "google_services_xml")
+        GOOGLE_SERVICES_XML eq Assignee { // Create new statements scope to not add to current scope
+            function("google_services_xml") {
+                "package_name" eq packageName.quote()
+                "google_services_json" eq googleServicesJson.quote()
+            }
         }
     }
+
     return GOOGLE_SERVICES_XML.toStatement()
 }
 
@@ -81,16 +84,19 @@ fun StatementsBuilder.googleServicesXml(
  */
 fun StatementsBuilder.crashlyticsAndroidLibrary(
     name: String = "crashlytics_lib",
-    packageName: String,
-    buildId: String,
+    packageName: String?,
+    buildId: String?,
     resourceFiles: String
 ): BazelDependency {
-    load("@tools_android//tools/crashlytics:defs.bzl", "crashlytics_android_library")
-    rule("crashlytics_android_library") {
-        "name" eq name.quote()
-        "package_name" eq packageName.quote()
-        "build_id" eq buildId.quote()
-        "resource_files" eq resourceFiles
+    if (!packageName.isNullOrBlank() && !buildId.isNullOrBlank()) {
+        load("@tools_android//tools/crashlytics:defs.bzl", "crashlytics_android_library")
+        rule("crashlytics_android_library") {
+            "name" eq name.quote()
+            "package_name" eq packageName.quote()
+            "build_id" eq buildId.quote()
+            "resource_files" eq resourceFiles
+        }
     }
+
     return BazelDependency.StringDependency(":$name")
 }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/di/GrazelComponent.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/di/GrazelComponent.kt
@@ -39,6 +39,7 @@ import com.grab.grazel.migrate.android.AndroidInstrumentationBinaryDataExtractor
 import com.grab.grazel.migrate.builder.AndroidBinaryTargetBuilderModule
 import com.grab.grazel.migrate.builder.AndroidInstrumentationBinaryTargetBuilderModule
 import com.grab.grazel.migrate.builder.AndroidLibTargetBuilderModule
+import com.grab.grazel.migrate.builder.CrashlyticsTargetBuilderModule
 import com.grab.grazel.migrate.builder.KtAndroidLibTargetBuilderModule
 import com.grab.grazel.migrate.builder.KtLibTargetBuilderModule
 import com.grab.grazel.migrate.dependencies.ArtifactsPinner
@@ -67,6 +68,7 @@ import javax.inject.Singleton
         AndroidLibTargetBuilderModule::class,
         AndroidBinaryTargetBuilderModule::class,
         AndroidInstrumentationBinaryTargetBuilderModule::class,
+        CrashlyticsTargetBuilderModule::class,
     ]
 )
 @Singleton

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/BazelTarget.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/BazelTarget.kt
@@ -41,4 +41,6 @@ interface BazelBuildTarget : BazelTarget {
 interface TargetBuilder {
     fun build(project: Project): List<BazelTarget>
     fun canHandle(project: Project): Boolean
+
+    fun sortOrder(): Int = Int.MAX_VALUE
 }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidBinaryTarget.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidBinaryTarget.kt
@@ -16,14 +16,12 @@
 
 package com.grab.grazel.migrate.android
 
-import com.grab.grazel.bazel.rules.GOOGLE_SERVICES_XML
 import com.grab.grazel.bazel.rules.Multidex
 import com.grab.grazel.bazel.rules.Visibility
 import com.grab.grazel.bazel.rules.androidBinary
 import com.grab.grazel.bazel.starlark.BazelDependency
 import com.grab.grazel.bazel.starlark.Statement
 import com.grab.grazel.bazel.starlark.statements
-import com.grab.grazel.bazel.starlark.toStatement
 import com.grab.grazel.migrate.BazelBuildTarget
 
 internal data class AndroidBinaryTarget(
@@ -45,16 +43,9 @@ internal data class AndroidBinaryTarget(
     val enableDataBinding: Boolean = false,
     val assetsGlob: List<String> = emptyList(),
     val assetsDir: String? = null,
-    val buildId: String? = null,
-    val googleServicesJson: String?,
-    val hasCrashlytics: Boolean
 ) : BazelBuildTarget {
     override fun statements(): List<Statement> = statements {
-        var resourceFiles = buildResources(res, ResValues(), customResourceSets, name)
-        var finalDeps = deps
-        if (googleServicesJson != null) {
-            resourceFiles += GOOGLE_SERVICES_XML.toStatement()
-        }
+        val resourceFiles = buildResources(res, resValues, customResourceSets, name)
 
         androidBinary(
             name = name,
@@ -70,7 +61,7 @@ internal data class AndroidBinaryTarget(
             manifest = manifest,
             manifestValues = manifestValues,
             resources = resourceFiles,
-            deps = finalDeps,
+            deps = deps,
             assetsGlob = assetsGlob,
             assetsDir = assetsDir
         )

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/Crashlytics.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/Crashlytics.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 Grabtaxi Holdings PTE LTD (GRAB)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grab.grazel.migrate.android
+
+import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.api.AndroidSourceSet
+import com.grab.grazel.GrazelExtension
+import com.grab.grazel.gradle.AndroidVariantDataSource
+import com.grab.grazel.gradle.getMigratableBuildVariants
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.getByType
+import javax.inject.Inject
+import javax.inject.Singleton
+
+internal data class CrashlyticsData(
+    val packageName: String?,
+    val buildId: String?,
+    val googleServicesJson: String?,
+)
+
+internal interface CrashlyticsDataExtractor {
+    fun extract(
+        project: Project,
+        androidSourceSets: List<AndroidSourceSet>,
+    ): CrashlyticsData
+}
+
+@Singleton
+internal class DefaultCrashlyticsDataExtractor @Inject constructor(
+    private val variantDataSource: AndroidVariantDataSource,
+    private val grazelExtension: GrazelExtension,
+    private val androidManifestParser: AndroidManifestParser,
+) : CrashlyticsDataExtractor {
+
+    override fun extract(
+        project: Project,
+        androidSourceSets: List<AndroidSourceSet>,
+    ): CrashlyticsData {
+
+        val googleServicesJson = findGoogleServicesJson(
+            variants = variantDataSource.getMigratableBuildVariants(project),
+            project = project
+        )
+
+        val buildId = grazelExtension.rules.googleServices.crashlytics.buildId
+
+        val extension = project.extensions.getByType<BaseExtension>()
+        val packageName = androidManifestParser.parsePackageName(
+            extension,
+            androidSourceSets,
+        )
+
+        return CrashlyticsData(
+            packageName = packageName,
+            buildId = buildId,
+            googleServicesJson = googleServicesJson,
+        )
+    }
+}

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/CrashlyticsTarget.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/CrashlyticsTarget.kt
@@ -24,9 +24,9 @@ import com.grab.grazel.migrate.BazelTarget
 
 class CrashlyticsTarget(
     override val name: String = "crashlytics_lib",
-    val packageName: String,
-    private val buildId: String,
-    private val googleServicesJson: String
+    val packageName: String? = null,
+    private val buildId: String? = null,
+    private val googleServicesJson: String? = null,
 ) : BazelTarget {
 
     override fun statements(): List<Statement> = com.grab.grazel.bazel.starlark.statements {

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/AndroidBinaryTargetBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/AndroidBinaryTargetBuilder.kt
@@ -16,8 +16,11 @@
 
 package com.grab.grazel.migrate.builder
 
+import com.grab.grazel.bazel.starlark.BazelDependency
 import com.grab.grazel.gradle.ConfigurationScope
 import com.grab.grazel.gradle.dependencies.variantNameSuffix
+import com.grab.grazel.gradle.hasCrashlytics
+import com.grab.grazel.gradle.hasGooglePlayServicesPlugin
 import com.grab.grazel.gradle.isAndroidApplication
 import com.grab.grazel.gradle.isKotlin
 import com.grab.grazel.migrate.BazelTarget
@@ -93,7 +96,7 @@ internal class AndroidBinaryTargetBuilder @Inject constructor(
                 listOf(
                     AndroidBinaryTarget(
                         name = "${binaryData.name}${mergedVariant.variantName.variantNameSuffix()}",
-                        deps = androidLibData.deps + binaryData.deps,
+                        deps = androidLibData.deps + binaryData.deps + crashlyticsDeps(project),
                         srcs = androidLibData.srcs,
                         multidex = binaryData.multidex,
                         debugKey = binaryData.debugKey,
@@ -104,50 +107,24 @@ internal class AndroidBinaryTargetBuilder @Inject constructor(
                         manifest = androidLibData.manifestFile,
                         manifestValues = binaryData.manifestValues,
                         res = androidLibData.res,
-                        resValues = androidLibData.resValues,
                         customResourceSets = androidLibData.extraRes,
                         assetsGlob = androidLibData.assets,
                         assetsDir = androidLibData.assetsDir,
-                        buildId = binaryData.buildId,
-                        googleServicesJson = binaryData.googleServicesJson,
-                        hasCrashlytics = binaryData.hasCrashlytics
                     )
                 )
             } + intermediateTargets
 
-        targets = addCrashlyticsTarget(targets)
-
         return targets
     }
 
-    private fun addCrashlyticsTarget(targets: List<BazelTarget>): List<BazelTarget> {
-        var resultTargets = targets
-        val androidTargetWithCrashlytics = resultTargets.firstOrNull { bazelTarget ->
-            bazelTarget is AndroidBinaryTarget &&
-                bazelTarget.hasCrashlytics &&
-                bazelTarget.buildId != null &&
-                bazelTarget.googleServicesJson != null
-        } as AndroidBinaryTarget?
-        if (androidTargetWithCrashlytics != null) {
-            val crashlyticsTarget = with(androidTargetWithCrashlytics) {
-                CrashlyticsTarget(
-                    packageName = packageName,
-                    buildId = buildId!!,
-                    googleServicesJson = googleServicesJson!!
-                )
-            }
-
-            resultTargets = resultTargets.map { bazelTarget ->
-                if (bazelTarget is AndroidBinaryTarget) {
-                    bazelTarget.copy(deps = bazelTarget.deps + crashlyticsTarget.toBazelDependency())
-                } else {
-                    bazelTarget
-                }
-            }.toMutableList()
-            resultTargets.add(0, crashlyticsTarget)
+    private fun crashlyticsDeps(project: Project): List<BazelDependency> =
+        if (project.hasGooglePlayServicesPlugin && project.hasCrashlytics) {
+            listOf(
+                CrashlyticsTarget().toBazelDependency()
+            )
+        } else {
+            emptyList()
         }
-        return resultTargets
-    }
 
     private fun buildKtAndroidTargets(project: Project): List<BazelTarget> {
         return buildList {

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/AndroidBinaryTargetBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/AndroidBinaryTargetBuilder.kt
@@ -157,4 +157,5 @@ internal class AndroidBinaryTargetBuilder @Inject constructor(
     }
 
     override fun canHandle(project: Project): Boolean = project.isAndroidApplication
+    override fun sortOrder(): Int = 1
 }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/AndroidInstrumentationBinaryTargetBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/AndroidInstrumentationBinaryTargetBuilder.kt
@@ -58,6 +58,8 @@ internal class AndroidInstrumentationBinaryTargetBuilder
     override fun canHandle(project: Project): Boolean =
         project.isAndroidApplication && project.hasTestInstrumentationRunner
 
+    override fun sortOrder(): Int = 3
+
     private fun Project.buildAndroidInstrumentationBinaryTargets(): List<BazelTarget> {
         return buildList {
             variantsMerger.merge(

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/AndroidLibTargetBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/AndroidLibTargetBuilder.kt
@@ -75,6 +75,8 @@ internal class AndroidLibTargetBuilder @Inject constructor(
     override fun canHandle(project: Project): Boolean = with(project) {
         isAndroid && !isKotlin && !isAndroidApplication
     }
+
+    override fun sortOrder(): Int = 2
 }
 
 private fun AndroidLibraryData.toAndroidLibTarget(suffix: String) = AndroidLibraryTarget(

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/CrashlyticsTargetBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/CrashlyticsTargetBuilder.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 Grabtaxi Holdings PTE LTD (GRAB)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grab.grazel.migrate.builder
+
+import com.android.build.gradle.api.AndroidSourceSet
+import com.grab.grazel.gradle.ConfigurationScope
+import com.grab.grazel.gradle.hasCrashlytics
+import com.grab.grazel.gradle.hasGooglePlayServicesPlugin
+import com.grab.grazel.gradle.isAndroidApplication
+import com.grab.grazel.migrate.BazelTarget
+import com.grab.grazel.migrate.TargetBuilder
+import com.grab.grazel.migrate.android.CrashlyticsData
+import com.grab.grazel.migrate.android.CrashlyticsDataExtractor
+import com.grab.grazel.migrate.android.CrashlyticsTarget
+import com.grab.grazel.migrate.android.DefaultCrashlyticsDataExtractor
+import com.grab.grazel.migrate.android.VariantsMerger
+import dagger.Binds
+import dagger.Module
+import dagger.multibindings.IntoSet
+import org.gradle.api.Project
+import javax.inject.Inject
+
+@Module
+internal interface CrashlyticsTargetBuilderModule {
+
+    @Binds
+    fun DefaultCrashlyticsDataExtractor.bindCrashlyticsDataExtractor(): CrashlyticsDataExtractor
+
+    @Binds
+    @IntoSet
+    fun CrashlyticsTargetBuilder.bindCrashlyticsTargetBuilder(): TargetBuilder
+}
+
+internal class CrashlyticsTargetBuilder @Inject constructor(
+    private val crashlyticsDataExtractor: CrashlyticsDataExtractor,
+    private val variantsMerger: VariantsMerger,
+) : TargetBuilder {
+
+    override fun build(project: Project): List<BazelTarget> =
+        listOf(
+            project.buildCrashlyticsTarget()
+        )
+
+    override fun canHandle(project: Project): Boolean =
+        project.isAndroidApplication &&
+            project.hasGooglePlayServicesPlugin &&
+            project.hasCrashlytics
+
+
+    private fun Project.buildCrashlyticsTarget(): BazelTarget =
+        variantsMerger
+            .merge(project, ConfigurationScope.BUILD)
+            .map { mergedVariant ->
+                mergedVariant.variant.sourceSets
+                    .filterIsInstance<AndroidSourceSet>()
+            }
+            .map { migratableSourceSets ->
+                crashlyticsDataExtractor.extract(
+                    project = project,
+                    androidSourceSets = migratableSourceSets,
+                )
+            }
+            .map { it.toTarget() }
+            .first()
+
+    private fun CrashlyticsData.toTarget(): CrashlyticsTarget =
+        CrashlyticsTarget(
+            packageName = packageName,
+            buildId = buildId,
+            googleServicesJson = googleServicesJson,
+        )
+}

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/CrashlyticsTargetBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/CrashlyticsTargetBuilder.kt
@@ -60,6 +60,7 @@ internal class CrashlyticsTargetBuilder @Inject constructor(
             project.hasGooglePlayServicesPlugin &&
             project.hasCrashlytics
 
+    override fun sortOrder(): Int = 0
 
     private fun Project.buildCrashlyticsTarget(): BazelTarget =
         variantsMerger

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/internal/ProjectBazelFileBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/internal/ProjectBazelFileBuilder.kt
@@ -35,7 +35,7 @@ class ProjectBazelFileBuilder(
 
     override fun build(): List<Statement> {
         return targetBuilders
-            .sortedBy { it.toString() }
+            .sortedWith(compareBy(TargetBuilder::sortOrder, TargetBuilder::toString))
             .filter { it.canHandle(project) }
             .flatMap { it.build(project) }
             .flatMap { it.statements() }

--- a/sample-android/BUILD.bazel
+++ b/sample-android/BUILD.bazel
@@ -1,3 +1,19 @@
+load("@tools_android//tools/googleservices:defs.bzl", "google_services_xml")
+
+GOOGLE_SERVICES_XML = google_services_xml(
+    package_name = "com.grab.grazel.android.sample",
+    google_services_json = "google-services.json",
+)
+
+load("@tools_android//tools/crashlytics:defs.bzl", "crashlytics_android_library")
+
+crashlytics_android_library(
+    name = "crashlytics_lib",
+    package_name = "com.grab.grazel.android.sample",
+    build_id = "042cb4d8-56f8-41a0-916a-9da28e94d1ba",
+    resource_files = GOOGLE_SERVICES_XML,
+)
+
 load("@grab_bazel_common//tools/custom_res:custom_res.bzl", "custom_res")
 
 android_binary(
@@ -257,20 +273,4 @@ android_instrumentation_binary(
         "@maven//:androidx_test_ext_junit",
         "@maven//:com_squareup_leakcanary_leakcanary_android",
     ],
-)
-
-load("@tools_android//tools/googleservices:defs.bzl", "google_services_xml")
-
-GOOGLE_SERVICES_XML = google_services_xml(
-    package_name = "com.grab.grazel.android.sample",
-    google_services_json = "google-services.json",
-)
-
-load("@tools_android//tools/crashlytics:defs.bzl", "crashlytics_android_library")
-
-crashlytics_android_library(
-    name = "crashlytics_lib",
-    package_name = "com.grab.grazel.android.sample",
-    build_id = "042cb4d8-56f8-41a0-916a-9da28e94d1ba",
-    resource_files = GOOGLE_SERVICES_XML,
 )

--- a/sample-android/BUILD.bazel
+++ b/sample-android/BUILD.bazel
@@ -1,19 +1,3 @@
-load("@tools_android//tools/googleservices:defs.bzl", "google_services_xml")
-
-GOOGLE_SERVICES_XML = google_services_xml(
-    package_name = "com.grab.grazel.android.sample",
-    google_services_json = "google-services.json",
-)
-
-load("@tools_android//tools/crashlytics:defs.bzl", "crashlytics_android_library")
-
-crashlytics_android_library(
-    name = "crashlytics_lib",
-    package_name = "com.grab.grazel.android.sample",
-    build_id = "042cb4d8-56f8-41a0-916a-9da28e94d1ba",
-    resource_files = GOOGLE_SERVICES_XML,
-)
-
 load("@grab_bazel_common//tools/custom_res:custom_res.bzl", "custom_res")
 
 android_binary(
@@ -47,7 +31,7 @@ android_binary(
             "src/main/res-debug/values/strings.xml",
         ]),
         target = "sample-android-flavor2-debug",
-    ) + GOOGLE_SERVICES_XML,
+    ),
     visibility = [
         "//visibility:public",
     ],
@@ -95,7 +79,7 @@ android_binary(
             "src/main/res-debug/values/strings.xml",
         ]),
         target = "sample-android-flavor1-debug",
-    ) + GOOGLE_SERVICES_XML,
+    ),
     visibility = [
         "//visibility:public",
     ],
@@ -273,4 +257,20 @@ android_instrumentation_binary(
         "@maven//:androidx_test_ext_junit",
         "@maven//:com_squareup_leakcanary_leakcanary_android",
     ],
+)
+
+load("@tools_android//tools/googleservices:defs.bzl", "google_services_xml")
+
+GOOGLE_SERVICES_XML = google_services_xml(
+    package_name = "com.grab.grazel.android.sample",
+    google_services_json = "google-services.json",
+)
+
+load("@tools_android//tools/crashlytics:defs.bzl", "crashlytics_android_library")
+
+crashlytics_android_library(
+    name = "crashlytics_lib",
+    package_name = "com.grab.grazel.android.sample",
+    build_id = "042cb4d8-56f8-41a0-916a-9da28e94d1ba",
+    resource_files = GOOGLE_SERVICES_XML,
 )


### PR DESCRIPTION
## Proposed Changes
According to the crashlytics [README.md](https://github.com/bazelbuild/tools_android/blob/master/tools/crashlytics/README.md) in tools_android, there is no need for the output of `google_services_xml` to be added to the `resource_files` of `android_binary` as the underlying implementation for `crashlytics_android_libarary` is already an `android_library` which can be added to `android_binary` as a dependency.

This PR also decouples the `CrashlyticsTarget` away from `AndroidBinaryTargetBuilder` and have a separate `CrashlyticsTargetBuilder` instead. A sort order was also implemented for `TargetBuilder` so that the order of these targets within `BUILD.bazel` is more deterministic

## Testing

<!--- Please describe how you tested your changes. -->

## Issues Fixed