### PR TITLE
Cleanup DI and remove `ProgressLogger`

### DIFF
--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/VariantsMerger.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/VariantsMerger.kt
@@ -33,8 +33,8 @@ internal class VariantsMerger @Inject constructor(
     @RootProject private val rootProject: Project,
 ) {
 
-    private val androidApplicationsModules =
-        rootProject.subprojects.filter { it.isAndroidApplication }
+    private val androidApplicationsModules = rootProject.subprojects
+        .filter { it.isAndroidApplication }
 
     fun merge(project: Project, scope: ConfigurationScope): Set<MergedVariant> {
         val moduleVariants = androidVariantDataSource.getMigratableVariants(project, scope)

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/AndroidBinaryTargetBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/AndroidBinaryTargetBuilder.kt
@@ -77,7 +77,7 @@ internal class AndroidBinaryTargetBuilder @Inject constructor(
         intermediateTargets: List<BazelTarget>
     ): List<BazelTarget> {
 
-        var targets = variantsMerger.merge(project, ConfigurationScope.BUILD)
+        val targets = variantsMerger.merge(project, ConfigurationScope.BUILD)
             .flatMap { mergedVariant ->
                 var androidLibData = androidLibDataExtractor.extract(project, mergedVariant)
                 val deps = if (project.isKotlin) {
@@ -157,5 +157,6 @@ internal class AndroidBinaryTargetBuilder @Inject constructor(
     }
 
     override fun canHandle(project: Project): Boolean = project.isAndroidApplication
+
     override fun sortOrder(): Int = 1
 }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/internal/ProjectBazelFileBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/internal/ProjectBazelFileBuilder.kt
@@ -29,7 +29,11 @@ class ProjectBazelFileBuilder(
 ) : BazelFileBuilder {
 
     @Singleton
-    class Factory @Inject constructor(private val targetBuilders: Set<@JvmSuppressWildcards TargetBuilder>) {
+    class Factory
+    @Inject
+    constructor(
+        private val targetBuilders: Set<@JvmSuppressWildcards TargetBuilder>
+    ) {
         fun create(project: Project) = ProjectBazelFileBuilder(project, targetBuilders)
     }
 

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/GenerateBazelScriptsTask.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/GenerateBazelScriptsTask.kt
@@ -30,7 +30,6 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
-import org.gradle.internal.logging.progress.ProgressLogger
 import org.gradle.kotlin.dsl.register
 import javax.inject.Inject
 
@@ -38,8 +37,7 @@ internal open class GenerateBazelScriptsTask
 @Inject
 constructor(
     private val migrationChecker: Lazy<MigrationChecker>,
-    private val bazelFileBuilder: Lazy<ProjectBazelFileBuilder.Factory>,
-    private val progressLogger: Lazy<ProgressLogger>
+    private val bazelFileBuilder: Lazy<ProjectBazelFileBuilder.Factory>
 ) : DefaultTask() {
 
     private val rootProject get() = project.rootProject
@@ -61,15 +59,13 @@ constructor(
             if (content.isNotEmpty()) {
                 content.writeToFile(buildBazelFile)
                 val generatedMessage = "Generated ${rootProject.relativePath(buildBazelFile)}"
-                progressLogger.get().progress(generatedMessage)
                 logger.quiet(generatedMessage.ansiGreen)
                 bazelIgnoreFile.delete()
             } else {
                 // No content was generated, delete the file
                 buildBazelFile.delete()
                 val deletedMessage = "Deleted ${rootProject.relativePath(buildBazelFile)}"
-                progressLogger.get().progress(deletedMessage.ansiGreen)
-                logger.quiet(deletedMessage)
+                logger.quiet(deletedMessage.ansiGreen)
             }
         } else {
             // If not migrateable but was already migrated, rename build.bazel to build.bazelignore if it exists
@@ -94,7 +90,6 @@ constructor(
                 TASK_NAME,
                 grazelComponent.migrationChecker(),
                 grazelComponent.projectBazelFileBuilderFactory(),
-                grazelComponent.progressLogger()
             ).apply {
                 configure {
                     group = GRAZEL_TASK_GROUP


### PR DESCRIPTION
## Proposed Changes

- Remove `ProgressLogger` since this was initially added when we have single task for migrating multiple projects, since now have individual tasks for projects this is no longer needed.