### PR TITLE
change AGP to compileOnly

### DIFF
--- a/grazel-gradle-plugin/build.gradle
+++ b/grazel-gradle-plugin/build.gradle
@@ -79,7 +79,7 @@ gradlePlugin {
 dependencies {
     implementation platform("org.jetbrains.kotlin:kotlin-bom")
     implementation libs.kotlin.gradle.plugin
-    implementation libs.android.gradle.plugin
+    compileOnly libs.android.gradle.plugin
 
     implementation libs.google.guava
     implementation libs.picnic

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/AndroidRules.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/AndroidRules.kt
@@ -16,6 +16,7 @@
 
 package com.grab.grazel.bazel.rules
 
+import com.android.builder.model.Version
 import com.grab.grazel.bazel.starlark.Assignee
 import com.grab.grazel.bazel.starlark.BazelDependency
 import com.grab.grazel.bazel.starlark.StatementsBuilder
@@ -214,7 +215,7 @@ internal const val DATABINDING_GROUP = "androidx.databinding"
 internal const val ANDROIDX_GROUP = "androidx.annotation"
 internal const val ANNOTATION_ARTIFACT = "annotation"
 internal val DATABINDING_ARTIFACTS by lazy {
-    val version = "7.2.2" // TODO(arun) Infer this from AGP
+    val version = Version.ANDROID_GRADLE_PLUGIN_VERSION
     listOf(
         MavenArtifact(DATABINDING_GROUP, "databinding-adapters", version),
         MavenArtifact(DATABINDING_GROUP, "databinding-compiler", version),


### PR DESCRIPTION
## Proposed Changes
Assume consumer set their own AGP instead of enforcing AGP version from Grazel

## Testing

<!--- Please describe how you tested your changes. -->

## Issues Fixed