### PR TITLE
Support build config fields configured with new `androidComponents` extension

### DIFF
--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/util/Reflect.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/util/Reflect.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Grabtaxi Holdings PTE LTD (GRAB)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grab.grazel.util
+
+import java.lang.reflect.Field
+
+internal fun Class<*>.findField(fieldName: String): Field? {
+    val field = try {
+        getDeclaredField(fieldName)
+    } catch (e: NoSuchFieldException) {
+        null
+    }
+    return field ?: superclass?.findField(fieldName)
+}
+
+internal fun <T> Any.fieldValue(fieldName: String): T? {
+    val field = this.javaClass.findField(fieldName)?.also { it.isAccessible = true }
+    @Suppress("UNCHECKED_CAST")
+    return field?.get(this) as? T?
+}

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/util/Project.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/util/Project.kt
@@ -21,11 +21,15 @@ import com.grab.grazel.di.DaggerGrazelComponent
 import com.grab.grazel.di.GrazelComponent
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.internal.project.DefaultProject
 
 /**
  * Forces an evaluation of the project thereby running all configurations
  */
-fun Project.doEvaluate(): MutableSet<Task> = getTasksByName("tasks", false)
+fun Project.doEvaluate() {
+    getTasksByName("tasks", false)
+    (this as DefaultProject).evaluate()
+}
 
 internal fun Project.createGrazelComponent(): GrazelComponent {
     return DaggerGrazelComponent.factory().create(this)

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/util/Truth.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/util/Truth.kt
@@ -1,6 +1,13 @@
 package com.grab.grazel.util
 
 import com.google.common.truth.IterableSubject
+import com.google.common.truth.MapSubject
 import com.google.common.truth.Truth
 
-fun Collection<*>.truth(): IterableSubject = Truth.assertThat(this)
+inline fun Collection<*>.truth(
+    assertions: IterableSubject.() -> Unit = {}
+): IterableSubject = Truth.assertThat(this).apply(assertions)
+
+inline fun Map<*, *>.truth(
+    assertions: MapSubject.() -> Unit = {}
+): MapSubject = Truth.assertThat(this).apply(assertions)

--- a/sample-android/BUILD.bazel
+++ b/sample-android/BUILD.bazel
@@ -128,6 +128,7 @@ build_config(
     strings = {
         "SOME_STRING": "Something",
         "VERSION_NAME": "1.0",
+        "VARIANT_NAME": "flavor2Debug",
     },
 )
 
@@ -194,6 +195,7 @@ build_config(
     strings = {
         "SOME_STRING": "Something",
         "VERSION_NAME": "1.0",
+        "VARIANT_NAME": "flavor1Debug",
     },
 )
 

--- a/sample-android/build.gradle
+++ b/sample-android/build.gradle
@@ -1,3 +1,5 @@
+import com.android.build.api.variant.BuildConfigField
+
 /*
  * Copyright 2022 Grabtaxi Holdings PTE LTD (GRAB)
  *
@@ -65,6 +67,12 @@ android {
         }
         flavor1 {
             dimension "service"
+        }
+    }
+
+    androidComponents {
+        onVariants(selector().all()) { variant ->
+            variant.buildConfigFields.put("VARIANT_NAME", new BuildConfigField("String", "\"$variant.name\"", null))
         }
     }
 

--- a/sample-android/src/main/java/com/grab/grazel/android/sample/MainActivity.kt
+++ b/sample-android/src/main/java/com/grab/grazel/android/sample/MainActivity.kt
@@ -73,5 +73,6 @@ class MainActivity : AppCompatActivity() {
         BuildConfig.DEBUG
         BuildConfig.VERSION_CODE
         BuildConfig.VERSION_NAME
+        BuildConfig.VARIANT_NAME
     }
 }


### PR DESCRIPTION
## Proposed Changes

If build config fields were generated by mutating `Variant` in the `androidComponents.onVariants` API then Grazel would not generate build config fields before. This is due to the fact the mutations in 
the new API does not reflect in the old API i.e `BaseVariant` and currently there does not seem to be a way to access `Variant` instance from the `androidComponents` API. Unfortunately we have to rely 
on reflection to access the component and get mutations applied and this is what this PR does. Long term, we should consider raising a FR to allow access to `Variant` extension in a read only fashion at least.
