### PR TITLE
Merge items in `glob` instead of using `+`

### DIFF
--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidLibraryData.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidLibraryData.kt
@@ -76,9 +76,10 @@ internal fun StatementsBuilder.buildResources(
     customResourceSets: List<ResourceSet>,
     targetName: String
 ): List<Assignee> {
-
-    val localResources = resources.map { glob(array(it.quote())) }
-
+    val localResources = when {
+        resources.isNotEmpty() -> listOf(glob(array(resources.quote)))
+        else -> emptyList()
+    }
     val customResources = if (customResourceSets.isNotEmpty()) {
         loadCustomRes()
         customResourceSets

--- a/sample-android-flavor/BUILD.bazel
+++ b/sample-android-flavor/BUILD.bazel
@@ -15,13 +15,13 @@ kt_db_android_library(
     ]),
     custom_package = "com.grab.grazel.android.flavor",
     manifest = "src/main/AndroidManifest.xml",
-    resource_files = glob([
-        "src/main/res/**",
-    ]) + glob([
-        "src/freeApp/res/**",
-    ]) + glob([
-        "src/flavor1/res/values/strings.xml",
-    ]),
+    resource_files = glob(
+        [
+            "src/main/res/**",
+            "src/freeApp/res/**",
+            "src/flavor1/res/values/strings.xml",
+        ],
+    ),
     visibility = [
         "//visibility:public",
     ],
@@ -55,7 +55,6 @@ kt_db_android_library(
     manifest = "src/main/AndroidManifest.xml",
     resource_files = glob([
         "src/main/res/**",
-    ]) + glob([
         "src/flavor1/res/values/strings.xml",
     ]),
     visibility = [
@@ -89,13 +88,13 @@ kt_db_android_library(
     ]),
     custom_package = "com.grab.grazel.android.flavor",
     manifest = "src/main/AndroidManifest.xml",
-    resource_files = glob([
-        "src/main/res/**",
-    ]) + glob([
-        "src/freeApp/res/**",
-    ]) + glob([
-        "src/flavor2/res/values/strings.xml",
-    ]),
+    resource_files = glob(
+        [
+            "src/main/res/**",
+            "src/freeApp/res/**",
+            "src/flavor2/res/values/strings.xml",
+        ],
+    ),
     visibility = [
         "//visibility:public",
     ],
@@ -129,7 +128,6 @@ kt_db_android_library(
     manifest = "src/main/AndroidManifest.xml",
     resource_files = glob([
         "src/main/res/**",
-    ]) + glob([
         "src/flavor2/res/values/strings.xml",
     ]),
     visibility = [


### PR DESCRIPTION
## Proposed Changes

Before

```python
resource_files = glob([
        "src/main/res/**",
    ]) + glob([
        "src/freeApp/res/**",
    ]) + glob([
        "src/flavor1/res/values/strings.xml",
    ])
```

After

```python
resource_files = glob(
     [
            "src/main/res/**",
            "src/freeApp/res/**",
            "src/flavor1/res/values/strings.xml",
     ],
),
```

Notes:

Need to remove adding constant items inside `glob` as it is wasteful, will address it separately.