### PR TITLE
Refactor hybrid build classes and disabled generating intermediate `android_library` resources target

### DIFF
--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/GrazelExtension.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/GrazelExtension.kt
@@ -18,6 +18,7 @@ package com.grab.grazel
 
 import com.grab.grazel.extension.AndroidExtension
 import com.grab.grazel.extension.DependenciesExtension
+import com.grab.grazel.extension.HybridExtension
 import com.grab.grazel.extension.RulesExtension
 import groovy.lang.Closure
 import org.gradle.api.Project
@@ -52,6 +53,8 @@ open class GrazelExtension(
 
     val rules = RulesExtension(rootProject.objects)
 
+    val hybrid = HybridExtension(rootProject.objects)
+
     /**
      * Android specific configuration used to configure parameters for android_binary or other android related
      * rules
@@ -65,6 +68,7 @@ open class GrazelExtension(
      * ```
      *
      * @param block Configuration block with [AndroidExtension] as the receiver
+     * @see AndroidExtension
      */
     fun android(block: AndroidExtension.() -> Unit) {
         block(android)
@@ -82,6 +86,7 @@ open class GrazelExtension(
      * }
      * ```
      * @param closure Closue for configuration with [AndroidExtension] instance as the delegate
+     * @see AndroidExtension
      */
     fun android(closure: Closure<*>) {
         closure.delegate = android
@@ -99,6 +104,7 @@ open class GrazelExtension(
      * ```
      *
      * @param block Configuration block with [DependenciesExtension] as the receiver
+     * @see DependenciesExtension
      */
     fun dependencies(block: DependenciesExtension.() -> Unit) {
         block(dependencies)
@@ -114,6 +120,7 @@ open class GrazelExtension(
      * }
      * ```
      * @param closure Closure for configuration with [DependenciesExtension] instance as delegate
+     * @see DependenciesExtension
      */
     fun dependencies(closure: Closure<*>) {
         closure.delegate = dependencies
@@ -121,8 +128,7 @@ open class GrazelExtension(
     }
 
     /**
-     * Top level rules configuration block to configure various rules. For list of available rule configurations, see
-     * [RulesExtension]
+     * Top level rules configuration block to configure various rules. For list of available rule configurations
      *
      * ```
      * rules {
@@ -131,14 +137,14 @@ open class GrazelExtension(
      * }
      * ```
      * @param block Configuration block with [RulesExtension] as the receiver
+     * @see RulesExtension
      */
     fun rules(block: RulesExtension.() -> Unit) {
         block(rules)
     }
 
     /**
-     * Top level rules configuration block to configure various rules. For list of available rule configurations, see
-     * [RulesExtension]
+     * Top level rules configuration block to configure various rules. For list of available rule configurations
      *
      * ```
      * rules {
@@ -147,9 +153,41 @@ open class GrazelExtension(
      * }
      * ```
      * @param closure Closure block for configuration with [RulesExtension] as the delegate
+     * @see RulesExtension
      */
     fun rules(closure: Closure<*>) {
         closure.delegate = rules
+        closure.call()
+    }
+
+    /**
+     * Extension to configure hybrid build related configurations.
+     *
+     * ```
+     * hybrid {
+     *
+     * }
+     * ```
+     * @see HybridExtension
+     * @param block Configuration block with [HybridExtension] as the receiver
+     */
+    fun hybrid(block: HybridExtension.() -> Unit) {
+        block(hybrid)
+    }
+
+    /**
+     * Extension to configure hybrid build related configurations.
+     *
+     * ```
+     * hybrid {
+     *
+     * }
+     * ```
+     * @see HybridExtension
+     * @param closure Closure block with [HybridExtension] as the delegate
+     */
+    fun hybrid(closure: Closure<*>) {
+        closure.delegate = hybrid
         closure.call()
     }
 }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/GrazelGradlePlugin.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/GrazelGradlePlugin.kt
@@ -18,7 +18,6 @@ package com.grab.grazel
 
 import com.grab.grazel.GrazelExtension.Companion.GRAZEL_EXTENSION
 import com.grab.grazel.di.DaggerGrazelComponent
-import com.grab.grazel.hybrid.doHybridBuild
 import com.grab.grazel.tasks.internal.TaskManager
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -37,6 +36,7 @@ class GrazelGradlePlugin : Plugin<Project> {
         val grazelComponent = DaggerGrazelComponent.factory().create(project)
 
         TaskManager(project, grazelComponent).configTasks()
-        project.doHybridBuild()
+
+        grazelComponent.hybridBuildExecutor().execute()
     }
 }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/exec/Bazel.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/exec/Bazel.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Grabtaxi Holdings PTE LTD (GRAB)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grab.grazel.bazel.exec
+
+import com.grab.grazel.util.LogOutputStream
+import org.gradle.api.Project
+import org.gradle.api.logging.LogLevel
+import org.gradle.process.ExecResult
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
+
+// TODO(arun) Inject exec operations and avoid using Project
+internal fun Project.bazelCommand(
+    command: String,
+    vararg args: String,
+    ignoreExit: Boolean = false,
+    outputStream: OutputStream? = null,
+    errorOutputStream: OutputStream? = null,
+): ExecResult {
+    val commands: List<String> = mutableListOf("bazelisk", command).apply {
+        addAll(args)
+    }
+    logger.quiet("Running ${commands.joinToString(separator = " ")}")
+    return exec {
+        commandLine(*commands.toTypedArray())
+        standardOutput = outputStream ?: LogOutputStream(logger, LogLevel.QUIET)
+        // Should be error but bazel wierdly outputs normal stuff to error
+        errorOutput = errorOutputStream ?: LogOutputStream(logger, LogLevel.QUIET)
+        isIgnoreExitValue = ignoreExit
+    }
+}
+
+// TODO(arun) Inject exec operations and avoid using Project
+internal fun Project.executeCommand(
+    vararg commands: String,
+    ignoreExit: Boolean = true
+): Pair<String, String> {
+    val stdOut = ByteArrayOutputStream()
+    val stdErr = ByteArrayOutputStream()
+    project.exec {
+        standardOutput = stdOut
+        errorOutput = stdErr
+        isIgnoreExitValue = ignoreExit
+        commandLine(*commands)
+    }
+    return stdOut.toString().trim() to stdErr.toString().trim()
+}

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/AndroidRules.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/AndroidRules.kt
@@ -181,6 +181,7 @@ fun StatementsBuilder.androidLibrary(
     resourceFiles: List<Assignee> = emptyList(),
     enableDataBinding: Boolean = false,
     deps: List<BazelDependency>,
+    tags: List<String> = emptyList(),
     assetsGlob: List<String> = emptyList(),
     assetsDir: String? = null
 ) {
@@ -203,6 +204,9 @@ fun StatementsBuilder.androidLibrary(
         }
         if (enableDataBinding) {
             "enable_data_binding" eq enableDataBinding.toString().capitalize()
+        }
+        tags.notEmpty {
+            "tags" eq array(tags.map(String::quote))
         }
         assetsDir?.let {
             "assets" eq glob(assetsGlob.quote)

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/di/GrazelComponent.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/di/GrazelComponent.kt
@@ -38,6 +38,8 @@ import com.grab.grazel.gradle.variant.DefaultAndroidVariantsExtractor
 import com.grab.grazel.gradle.variant.VariantBuilder
 import com.grab.grazel.gradle.variant.VariantMatcher
 import com.grab.grazel.gradle.variant.VariantModule
+import com.grab.grazel.hybrid.HybridBuildExecutor
+import com.grab.grazel.hybrid.HybridBuildModule
 import com.grab.grazel.migrate.android.AndroidInstrumentationBinaryDataExtractor
 import com.grab.grazel.migrate.builder.AndroidBinaryTargetBuilderModule
 import com.grab.grazel.migrate.builder.AndroidInstrumentationBinaryTargetBuilderModule
@@ -74,7 +76,9 @@ internal interface GrazelComponent {
 
     @Component.Factory
     interface Factory {
-        fun create(@BindsInstance @RootProject rootProject: Project): GrazelComponent
+        fun create(
+            @BindsInstance @RootProject rootProject: Project
+        ): GrazelComponent
     }
 
     fun extension(): GrazelExtension
@@ -85,6 +89,7 @@ internal interface GrazelComponent {
     fun artifactsPinner(): Lazy<ArtifactsPinner>
     fun dependenciesDataSource(): Lazy<DependenciesDataSource>
     fun mavenInstallArtifactsCalculator(): Lazy<MavenInstallArtifactsCalculator>
+    fun hybridBuildExecutor(): HybridBuildExecutor
 
     fun androidInstrumentationBinaryDataExtractor(): Lazy<AndroidInstrumentationBinaryDataExtractor>
     fun variantBuilder(): Lazy<VariantBuilder>
@@ -95,7 +100,8 @@ internal interface GrazelComponent {
     includes = [
         MigrationCriteriaModule::class,
         DependenciesModule::class,
-        VariantModule::class
+        HybridBuildModule::class,
+        VariantModule::class,
     ]
 )
 internal interface GrazelModule {

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/extension/HybridExtension.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/extension/HybridExtension.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 Grabtaxi Holdings PTE LTD (GRAB)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grab.grazel.extension
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.kotlin.dsl.property
+
+/**
+ * Extension to configure hybrid builds.
+ */
+data class HybridExtension(
+    private val objects: ObjectFactory,
+    /**
+     * When set to true, will attempt to do hybrid build by running bazel build on all available
+     * targets during configuration phase and then replace gradle project dependencies with bazel
+     * build artifacts.
+     *
+     * Note: Not optimized for performance and only used for ensuring correctness.
+     */
+    val enabled: Property<Boolean> = objects
+        .property<Boolean>()
+        .convention(false)
+)

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/hybrid/DependencySubstitution.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/hybrid/DependencySubstitution.kt
@@ -16,6 +16,7 @@
 
 package com.grab.grazel.hybrid
 
+import com.grab.grazel.di.qualifiers.RootProject
 import com.grab.grazel.gradle.isMigrated
 import com.jakewharton.picnic.TextAlignment.MiddleCenter
 import com.jakewharton.picnic.table
@@ -26,41 +27,107 @@ import org.gradle.api.artifacts.DependencySet
 import org.gradle.api.artifacts.ProjectDependency
 import java.io.File
 import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
 
-/**
- * Register rules for substituting modules built by Bazel.
- *
- * @receiver `Project` The root project instance
- */
-internal fun Project.registerDependencySubstitutionRules(
-    artifactSearcherFactory: ArtifactSearcherFactory = DefaultArtifactSearcherFactory()
-) {
-    if (this != rootProject) {
-        throw IllegalArgumentException("Expected root project instance for substituting dependencies")
+interface DependencySubstitution {
+    fun register()
+}
+
+@Singleton
+class DefaultDependencySubstitution
+@Inject
+constructor(
+    @param:RootProject private val rootProject: Project,
+    private val artifactSearcher: ArtifactSearcher,
+) : DependencySubstitution {
+
+    private fun performSubstitution(
+        sourceProject: Project,
+        configuration: Configuration,
+        dependencySet: DependencySet,
+        artifactCache: Map<String, List<File>>
+    ) {
+        val migratedProjects = dependencySet.asSequence()
+            .filterIsInstance<ProjectDependency>()
+            .filter { it.dependencyProject.isMigrated }
+            .toList()
+
+        if (migratedProjects.isEmpty()) return
+
+        dependencySet.removeAll(migratedProjects.toSet())
+
+        table {
+            cellStyle {
+                border = true
+            }
+            header {
+                cellStyle {
+                    alignment = MiddleCenter
+                }
+                row {
+                    cell(sourceProject.path) {
+                        columnSpan = 3
+                    }
+                }
+                row("Configuration", "Project", "Substitution Artifacts")
+            }
+            body {
+                migratedProjects.forEach { projectDependency: ProjectDependency ->
+                    val rootProject = sourceProject.rootProject
+                    val depProject = projectDependency.dependencyProject
+                    val buildArtifacts = artifactCache.getOrDefault(depProject.path, emptyList())
+
+                    if (buildArtifacts.isNotEmpty()) {
+                        val artifactNames = buildArtifacts.map { it.name }
+                        val dependency = sourceProject
+                            .dependencies
+                            .create(rootProject.files(buildArtifacts))
+                        dependencySet.add(dependency)
+                        row(configuration.name, depProject.path, artifactNames)
+                    } else {
+                        sourceProject.logger.error(
+                            "Build artifact was not found for " +
+                                "${depProject.path}, skipping substitution"
+                        )
+                        throw GradleException(
+                            "Dependency substitution failed for " +
+                                "${sourceProject.path} for dependency ${depProject.path}"
+                        )
+                    }
+                }
+            }
+        }.let { table -> println(table.toString()) }
     }
-    afterEvaluate {
-        logger.debug("Caching migrated modules and their artifacts")
-        var measuredMillis = System.currentTimeMillis()
 
-        val artifactCache = subprojects
-            .filter(Project::isMigrated)
-            .map { project ->
-                val artifactSearcher = artifactSearcherFactory.newInstance(project)
-                val builtArtifacts = artifactSearcher.findArtifacts()
-                project.path to builtArtifacts
-            }.toMap()
+    override fun register() {
+        rootProject.afterEvaluate {
+            logger.debug("Caching migrated modules and their artifacts")
+            var measuredMillis = System.currentTimeMillis()
 
-        measuredMillis = System.currentTimeMillis() - measuredMillis
-        val measuredSeconds = TimeUnit.MILLISECONDS.toSeconds(measuredMillis)
-        logger.quiet("Caching artifacts took $measuredSeconds seconds.")
+            val artifactCache = subprojects
+                .filter(Project::isMigrated).associate { project ->
+                    val builtArtifacts = artifactSearcher.findArtifacts()
+                    project.path to builtArtifacts
+                }
 
-        subprojects {
-            afterEvaluate {
-                val sourceProject = this
-                configurations.configureEach {
-                    val configuration = this
-                    withDependencies {
-                        performSubstitution(sourceProject, configuration, this, artifactCache)
+            measuredMillis = System.currentTimeMillis() - measuredMillis
+            val measuredSeconds = TimeUnit.MILLISECONDS.toSeconds(measuredMillis)
+            logger.quiet("Caching artifacts took $measuredSeconds seconds.")
+
+            subprojects {
+                afterEvaluate {
+                    val sourceProject = this
+                    configurations.configureEach {
+                        val configuration = this
+                        withDependencies {
+                            performSubstitution(
+                                sourceProject,
+                                configuration,
+                                this,
+                                artifactCache
+                            )
+                        }
                     }
                 }
             }
@@ -68,54 +135,3 @@ internal fun Project.registerDependencySubstitutionRules(
     }
 }
 
-private fun performSubstitution(
-    sourceProject: Project,
-    configuration: Configuration,
-    dependencySet: DependencySet,
-    artifactCache: Map<String, List<File>>
-) {
-    val migratedProjects = dependencySet.asSequence()
-        .filterIsInstance<ProjectDependency>()
-        .filter { it.dependencyProject.isMigrated }
-        .toList()
-
-    if (migratedProjects.isEmpty()) return
-
-    dependencySet.removeAll(migratedProjects)
-
-    table {
-        cellStyle {
-            border = true
-        }
-        header {
-            cellStyle {
-                alignment = MiddleCenter
-            }
-            row {
-                cell(sourceProject.path) {
-                    columnSpan = 3
-                }
-            }
-            row("Configuration", "Project", "Substitution Artifacts")
-        }
-        body {
-            migratedProjects.forEach { projectDependency: ProjectDependency ->
-                val rootProject = sourceProject.rootProject
-                val depProject = projectDependency.dependencyProject
-                val buildArtifacts = artifactCache.getOrDefault(depProject.path, emptyList())
-
-                if (buildArtifacts.isNotEmpty()) {
-                    val artifactNames = buildArtifacts.map { it.name }
-                    val dependency = sourceProject
-                        .dependencies
-                        .create(rootProject.files(buildArtifacts))
-                    dependencySet.add(dependency)
-                    row(configuration.name, depProject.path, artifactNames)
-                } else {
-                    sourceProject.logger.error("Build artifact was not found for ${depProject.path}, skipping substitution")
-                    throw GradleException("Dependency substitution failed for ${sourceProject.path} for dependency ${depProject.path}")
-                }
-            }
-        }
-    }.let { table -> println(table.toString()) }
-}

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/hybrid/HybridBuildExecutor.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/hybrid/HybridBuildExecutor.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2023 Grabtaxi Holdings PTE LTD (GRAB)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grab.grazel.hybrid
+
+import com.grab.grazel.GrazelExtension
+import com.grab.grazel.bazel.exec.bazelCommand
+import com.grab.grazel.bazel.exec.executeCommand
+import com.grab.grazel.di.qualifiers.RootProject
+import com.grab.grazel.gradle.isMigrated
+import com.grab.grazel.util.KT_INTERMEDIATE_TARGET_SUFFIX
+import org.gradle.api.Project
+import javax.inject.Inject
+import javax.inject.Singleton
+
+internal interface HybridBuildExecutor {
+
+    fun buildAarTargets()
+
+    fun execute()
+}
+
+@Singleton
+internal class DefaultHybridBuildExecutor
+@Inject constructor(
+    @param:RootProject private val rootProject: Project,
+    private val grazelExtension: GrazelExtension,
+    private val dependencySubstitution: DependencySubstitution
+) : HybridBuildExecutor {
+
+    private val enabled get() = grazelExtension.hybrid.enabled.get()
+
+    /**
+     * Given a combined sequence of `android_library` and `kt_android_library` targets will return
+     * unique targets i.e `android_library` alone.
+     */
+    internal fun findUniqueAarTargets(aarTargets: Sequence<String>): List<String> {
+        // Filter out _base target added by kt_android_library
+        val allAarTargets = aarTargets.map {
+            if (it.endsWith(KT_INTERMEDIATE_TARGET_SUFFIX)) {
+                it.split(KT_INTERMEDIATE_TARGET_SUFFIX).first()
+            } else it
+        }
+        // The remaining unique entries are aar targets
+        return mutableMapOf<String, String>()
+            .apply {
+                allAarTargets.forEach { target ->
+                    if (containsKey(target))
+                        remove(target)
+                    else {
+                        put(target, target)
+                    }
+                }
+            }.keys
+            .asSequence()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .map { "$it.aar" }
+            .toList()
+    }
+
+
+    private fun collectDatabindingAarTargets(aarTargets: Sequence<String>) = aarTargets
+        .filter { it.isNotEmpty() }
+        .map { "$it.aar" }
+        .toList()
+
+    override fun buildAarTargets() {
+        // Query android library targets
+        val (bazelAarOut, _) = rootProject.executeCommand(
+            "bazelisk",
+            "query",
+            "kind(android_library, //...:*)"
+        )
+
+        // Query databinding aars
+        val (databindingAar, _) = rootProject.executeCommand(
+            "bazelisk",
+            "query",
+            "kind(databinding_aar, //...:*)"
+        )
+
+        val aarTargets = findUniqueAarTargets(bazelAarOut.lineSequence()) +
+            collectDatabindingAarTargets(databindingAar.lineSequence())
+        rootProject.logger.quiet("Found aar targets : $aarTargets")
+
+        rootProject.bazelCommand(
+            "build",
+            *aarTargets.distinct().toTypedArray(),
+            ignoreExit = true
+        )
+    }
+
+    override fun execute() {
+        if (rootProject.isMigrated && enabled) {
+            rootProject.bazelCommand("build", "//...")
+            buildAarTargets()
+            rootProject.bazelCommand("shutdown")
+            dependencySubstitution.register()
+        }
+    }
+}

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/BazelTarget.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/BazelTarget.kt
@@ -35,6 +35,7 @@ interface BazelBuildTarget : BazelTarget {
     val deps: List<BazelDependency>
     val srcs: List<String>
     val visibility: Visibility
+    val tags: List<String>
 }
 
 

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidBinaryTarget.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidBinaryTarget.kt
@@ -29,6 +29,7 @@ internal data class AndroidBinaryTarget(
     override val visibility: Visibility = Visibility.Public,
     override val deps: List<BazelDependency>,
     override val srcs: List<String>,
+    override val tags: List<String> = emptyList(),
     val crunchPng: Boolean = false,
     val packageName: String,
     val dexShards: Int? = null,

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidInstrumentationBinaryTarget.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidInstrumentationBinaryTarget.kt
@@ -27,6 +27,7 @@ internal data class AndroidInstrumentationBinaryTarget(
     override val name: String,
     override val deps: List<BazelDependency>,
     override val srcs: List<String>,
+    override val tags: List<String> = emptyList(),
     override val visibility: Visibility = Visibility.Public,
     val associates: List<BazelDependency> = emptyList(),
     val customPackage: String,

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidLibraryDataExtractor.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidLibraryDataExtractor.kt
@@ -32,6 +32,7 @@ import com.grab.grazel.gradle.dependencies.GradleDependencyToBazelDependency
 import com.grab.grazel.gradle.hasDatabinding
 import com.grab.grazel.gradle.isAndroid
 import com.grab.grazel.gradle.variant.MatchedVariant
+import com.grab.grazel.gradle.variant.nameSuffix
 import com.grab.grazel.migrate.dependencies.calculateDirectDependencyTags
 import com.grab.grazel.migrate.kotlin.kotlinParcelizeDeps
 import dagger.Lazy
@@ -118,7 +119,7 @@ internal class DefaultAndroidLibraryDataExtractor @Inject constructor(
         } else emptyList()
 
         return AndroidLibraryData(
-            name = name,
+            name = name + matchedVariant.nameSuffix,
             srcs = srcs,
             res = res,
             assets = assets,

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidLibraryTarget.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidLibraryTarget.kt
@@ -24,8 +24,9 @@ import com.grab.grazel.migrate.BazelBuildTarget
 
 internal data class AndroidLibraryTarget(
     override val name: String,
-    override val deps: List<BazelDependency>,
     override val srcs: List<String> = emptyList(),
+    override val deps: List<BazelDependency>,
+    override val tags: List<String> = emptyList(),
     override val visibility: Visibility = Visibility.Public,
     val enableDataBinding: Boolean = false,
     val projectName: String = name,
@@ -48,6 +49,7 @@ internal data class AndroidLibraryTarget(
             resourceFiles = resourceFiles,
             visibility = visibility,
             deps = deps,
+            tags = tags,
             assetsGlob = assetsGlob,
             assetsDir = assetsDir
         )

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidUnitTestTarget.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidUnitTestTarget.kt
@@ -24,12 +24,12 @@ import com.grab.grazel.migrate.BazelBuildTarget
 
 internal data class AndroidUnitTestTarget(
     override val name: String,
-    override val deps: List<BazelDependency>,
     override val srcs: List<String> = emptyList(),
+    override val deps: List<BazelDependency>,
+    override val tags: List<String> = emptyList(),
     override val visibility: Visibility = Visibility.Public,
     val associates: List<BazelDependency> = emptyList(),
     val customPackage: String,
-    val tags: List<String> = emptyList(),
     val resources: List<String> = emptyList(),
     val additionalSrcSets: List<String> = emptyList(),
 ) : BazelBuildTarget {

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/AndroidBinaryTargetBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/AndroidBinaryTargetBuilder.kt
@@ -177,23 +177,22 @@ constructor(
             project = project,
             sourceSetType = SourceSetType.JAVA_KOTLIN,
             matchedVariant = matchedVariant
-        ).copy(name = "${project.name}_lib", hasDatabinding = false)
+        ).copy(hasDatabinding = false)
 
         val deps = androidProjectData.deps.toMutableList()
 
         with(androidProjectData) {
-            toBuildConfigTarget(matchedVariant.nameSuffix).also {
+            toBuildConfigTarget().also {
                 deps += it.toBazelDependency()
                 add(it)
             }
         }
-        androidProjectData
-            .copy(
-                name = "${androidProjectData.name}${matchedVariant.nameSuffix}",
-                deps = deps,
-                tags = emptyList() // Don't generate classpath reduction tags for final binary target
-            ).toKtLibraryTarget()
-            ?.also { add(it) }
+
+        androidProjectData.copy(
+            name = "${project.name}_lib${matchedVariant.nameSuffix}",
+            deps = deps,
+            tags = emptyList() // Don't generate classpath reduction tags for final binary target
+        ).toKtLibraryTarget()?.let(::add)
     }
 
     override fun canHandle(project: Project) = project.isAndroidApplication

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/AndroidLibTargetBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/builder/AndroidLibTargetBuilder.kt
@@ -22,7 +22,6 @@ import com.grab.grazel.gradle.isAndroid
 import com.grab.grazel.gradle.isAndroidApplication
 import com.grab.grazel.gradle.isKotlin
 import com.grab.grazel.gradle.variant.VariantMatcher
-import com.grab.grazel.gradle.variant.nameSuffix
 import com.grab.grazel.migrate.BazelTarget
 import com.grab.grazel.migrate.TargetBuilder
 import com.grab.grazel.migrate.android.AndroidLibraryData
@@ -46,7 +45,7 @@ internal interface AndroidLibTargetBuilderModule {
 
 @Singleton
 internal class AndroidLibTargetBuilder @Inject constructor(
-    private val projectDataExtractor: AndroidLibraryDataExtractor,
+    private val androidLibraryDataExtractor: AndroidLibraryDataExtractor,
     private val unitTestDataExtractor: AndroidUnitTestDataExtractor,
     private val testExtension: TestExtension,
     private val variantMatcher: VariantMatcher,
@@ -55,9 +54,9 @@ internal class AndroidLibTargetBuilder @Inject constructor(
     override fun build(project: Project): List<BazelTarget> {
         return variantMatcher.matchedVariants(project, ConfigurationScope.BUILD)
             .map { matchedVariant ->
-                projectDataExtractor
+                androidLibraryDataExtractor
                     .extract(project, matchedVariant)
-                    .toAndroidLibTarget(matchedVariant.nameSuffix)
+                    .toAndroidLibTarget()
             } + unitTestsTargets(project)
     }
 
@@ -80,8 +79,8 @@ internal class AndroidLibTargetBuilder @Inject constructor(
     override fun sortOrder(): Int = 2
 }
 
-private fun AndroidLibraryData.toAndroidLibTarget(suffix: String) = AndroidLibraryTarget(
-    name = "$name$suffix",
+private fun AndroidLibraryData.toAndroidLibTarget() = AndroidLibraryTarget(
+    name = name,
     srcs = srcs,
     deps = deps,
     enableDataBinding = hasDatabinding,

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/dependencies/ArtifactsPinner.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/dependencies/ArtifactsPinner.kt
@@ -16,9 +16,9 @@
 
 package com.grab.grazel.migrate.dependencies
 
+import com.grab.grazel.bazel.exec.bazelCommand
 import com.grab.grazel.di.qualifiers.RootProject
 import com.grab.grazel.extension.MavenInstallExtension
-import com.grab.grazel.hybrid.bazelCommand
 import com.grab.grazel.migrate.dependencies.MavenPinningError.InvalidSignature
 import com.grab.grazel.migrate.dependencies.MavenPinningError.JsonCorrupted
 import com.grab.grazel.util.ansiYellow

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/KtLibraryTarget.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/KtLibraryTarget.kt
@@ -29,9 +29,10 @@ import com.grab.grazel.migrate.android.buildResources
 
 internal data class KtLibraryTarget(
     override val name: String,
-    override val deps: List<BazelDependency>,
     override val srcs: List<String>,
+    override val deps: List<BazelDependency>,
     override val visibility: Visibility = Visibility.Public,
+    override val tags: List<String> = emptyList(),
     val projectName: String = name,
     val kotlinProjectType: KotlinProjectType = KotlinProjectType.Jvm,
     val packageName: String? = null,
@@ -42,7 +43,6 @@ internal data class KtLibraryTarget(
     val plugins: List<BazelDependency> = emptyList(),
     val assetsGlob: List<String> = emptyList(),
     val assetsDir: String? = null,
-    val tags: List<String> = emptyList(),
 ) : BazelBuildTarget {
 
     override fun statements(): List<Statement> = statements {

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/UnitTestTarget.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/UnitTestTarget.kt
@@ -24,11 +24,11 @@ import com.grab.grazel.migrate.BazelBuildTarget
 
 internal data class UnitTestTarget(
     override val name: String,
-    override val deps: List<BazelDependency>,
     override val srcs: List<String> = emptyList(),
+    override val deps: List<BazelDependency>,
+    override val tags: List<String> = emptyList(),
     override val visibility: Visibility = Visibility.Public,
     val associates: List<BazelDependency> = emptyList(),
-    val tags: List<String> = emptyList(),
     val additionalSrcSets: List<String> = emptyList(),
 ) : BazelBuildTarget {
     override fun statements() = statements {

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/GenerateBuildifierScriptTask.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/GenerateBuildifierScriptTask.kt
@@ -17,7 +17,7 @@
 package com.grab.grazel.tasks.internal
 
 import com.grab.grazel.di.qualifiers.RootProject
-import com.grab.grazel.hybrid.bazelCommand
+import com.grab.grazel.bazel.exec.bazelCommand
 import com.grab.grazel.util.BUILDIFIER
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/TasksManager.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/TasksManager.kt
@@ -16,9 +16,9 @@
 
 package com.grab.grazel.tasks.internal
 
+import com.grab.grazel.bazel.exec.bazelCommand
 import com.grab.grazel.di.GrazelComponent
 import com.grab.grazel.di.qualifiers.RootProject
-import com.grab.grazel.hybrid.bazelCommand
 import com.grab.grazel.util.BAZEL_BUILD_ALL_TASK_NAME
 import com.grab.grazel.util.BAZEL_CLEAN_TASK_NAME
 import com.grab.grazel.util.BUILD_BAZEL
@@ -36,7 +36,9 @@ internal const val GRAZEL_TASK_GROUP = "bazel"
  *
  * @param rootProject  The root gradle project instance
  */
-internal class TaskManager @Inject constructor(
+internal class TaskManager
+@Inject
+constructor(
     @param:RootProject private val rootProject: Project,
     private val grazelComponent: GrazelComponent
 ) {

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/util/Constants.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/util/Constants.kt
@@ -16,9 +16,6 @@
 
 package com.grab.grazel.util
 
-internal const val BAZEL_ENABLED = "bazelEnabled"
-
-// Name of kt_android_library's aar target
 internal const val KT_INTERMEDIATE_TARGET_SUFFIX = "_base"
 
 // TASK NAMES

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/hybrid/HybridBuildExecutorTest.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/hybrid/HybridBuildExecutorTest.kt
@@ -16,10 +16,27 @@
 
 package com.grab.grazel.hybrid
 
+import com.grab.grazel.buildProject
+import com.grab.grazel.util.addGrazelExtension
+import com.grab.grazel.util.createGrazelComponent
+import org.gradle.api.Project
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 
-class HybridKtTest {
+class HybridBuildExecutorTest {
+
+    private lateinit var rootProject: Project
+    private lateinit var hybridBuildExecutor: DefaultHybridBuildExecutor
+
+    @Before
+    fun setup() {
+        rootProject = buildProject("root")
+        rootProject.addGrazelExtension()
+        hybridBuildExecutor = rootProject
+            .createGrazelComponent()
+            .hybridBuildExecutor() as DefaultHybridBuildExecutor
+    }
 
     @Test
     fun `when multiple android library targets are there assert android_library targets are calculated`() {
@@ -29,7 +46,7 @@ class HybridKtTest {
             "//base/another_target_base" // kt_android_library_base
         )
 
-        val uniqueTargets = findUniqueAarTargets(aarTargets = allAarTargets)
+        val uniqueTargets = hybridBuildExecutor.findUniqueAarTargets(aarTargets = allAarTargets)
         assertTrue(uniqueTargets.size == 1)
         assertTrue(uniqueTargets.first() == "//base/target.aar")
     }

--- a/sample-android/BUILD.bazel
+++ b/sample-android/BUILD.bazel
@@ -49,7 +49,7 @@ android_binary(
 load("@grab_bazel_common//tools/build_config:build_config.bzl", "build_config")
 
 build_config(
-    name = "sample-android_lib-flavor1-free-debug-build-config",
+    name = "sample-android-flavor1-free-debug-build-config",
     package_name = "com.grab.grazel.android.sample",
     booleans = {
         "SOME_BOOLEAN": "false",
@@ -103,7 +103,7 @@ kt_android_library(
         "//visibility:public",
     ],
     deps = [
-        ":sample-android_lib-flavor1-free-debug-build-config",
+        ":sample-android-flavor1-free-debug-build-config",
         "//:dagger",
         "//:parcelize",
         "//sample-android-flavor:sample-android-flavor-flavor1-free-debug",
@@ -179,7 +179,7 @@ android_binary(
 load("@grab_bazel_common//tools/build_config:build_config.bzl", "build_config")
 
 build_config(
-    name = "sample-android_lib-flavor1-paid-debug-build-config",
+    name = "sample-android-flavor1-paid-debug-build-config",
     package_name = "com.grab.grazel.android.sample",
     booleans = {
         "SOME_BOOLEAN": "false",
@@ -233,7 +233,7 @@ kt_android_library(
         "//visibility:public",
     ],
     deps = [
-        ":sample-android_lib-flavor1-paid-debug-build-config",
+        ":sample-android-flavor1-paid-debug-build-config",
         "//:dagger",
         "//:parcelize",
         "//sample-android-flavor:sample-android-flavor-flavor1-paid-debug",
@@ -309,7 +309,7 @@ android_binary(
 load("@grab_bazel_common//tools/build_config:build_config.bzl", "build_config")
 
 build_config(
-    name = "sample-android_lib-flavor2-free-debug-build-config",
+    name = "sample-android-flavor2-free-debug-build-config",
     package_name = "com.grab.grazel.android.sample",
     booleans = {
         "SOME_BOOLEAN": "false",
@@ -363,7 +363,7 @@ kt_android_library(
         "//visibility:public",
     ],
     deps = [
-        ":sample-android_lib-flavor2-free-debug-build-config",
+        ":sample-android-flavor2-free-debug-build-config",
         "//:dagger",
         "//:parcelize",
         "//sample-android-flavor:sample-android-flavor-flavor2-free-debug",
@@ -439,7 +439,7 @@ android_binary(
 load("@grab_bazel_common//tools/build_config:build_config.bzl", "build_config")
 
 build_config(
-    name = "sample-android_lib-flavor2-paid-debug-build-config",
+    name = "sample-android-flavor2-paid-debug-build-config",
     package_name = "com.grab.grazel.android.sample",
     booleans = {
         "SOME_BOOLEAN": "false",
@@ -493,7 +493,7 @@ kt_android_library(
         "//visibility:public",
     ],
     deps = [
-        ":sample-android_lib-flavor2-paid-debug-build-config",
+        ":sample-android-flavor2-paid-debug-build-config",
         "//:dagger",
         "//:parcelize",
         "//sample-android-flavor:sample-android-flavor-flavor2-paid-debug",


### PR DESCRIPTION
## Proposed Changes

- Cleans up hybrid build classes and refactor them to use DI

- Introduce hybrid build extension to control hybrid instead of gradle property `grazel.bazelEnabled`

- For supporting hybrid builds we used to generate a `android_library` res target for holding resources, that is removed in this PR. A proper approach would be to write something to `databinding_aar` in bazel_common and use that here to simply the amount of work grazel needs to do.

-  Note: https://github.com/grab/Grazel/issues/66 still remains open and this PR does not fix the issue. Probably needs a larger refactor to accomodate variants and to move away from doing everything in configuration phase. 
