### PR TITLE
Fix GoogleServiesJsonExtractor for variant detection

### DIFF
--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/GoogleServices.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/GoogleServices.kt
@@ -55,8 +55,7 @@ constructor() : GoogleServicesJsonExtractor {
          * https://github.com/google/play-services-plugins/blob/cce869348a9f4989d4a77bf9595ab6c073a8c441/google-services-plugin/src/main/groovy/com/google/gms/googleservices/GoogleServicesTask.java#L532
          */
         val variantSources = matchedVariant.variant.sourceSets.asSequence()
-            .flatMap { it.javaDirectories.asSequence() }
-            .map { File(it.parent, GOOGLE_SERVICES_JSON) }
+            .map { File(it.manifestFile.parent, GOOGLE_SERVICES_JSON) }
             .toList()
             .reversed()
         val projectDirSource = File(project.projectDir, GOOGLE_SERVICES_JSON)

--- a/sample-android/BUILD.bazel
+++ b/sample-android/BUILD.bazel
@@ -124,7 +124,7 @@ crashlytics_android_library(
     build_id = "042cb4d8-56f8-41a0-916a-9da28e94d1ba",
     resource_files = google_services_xml(
         package_name = "com.grab.grazel.android.sample.free",
-        google_services_json = "src/flavor1Free/google-services.json",
+        google_services_json = "src/flavor1FreeDebug/google-services.json",
     ),
 )
 

--- a/sample-android/src/flavor1FreeDebug/google-services.json
+++ b/sample-android/src/flavor1FreeDebug/google-services.json
@@ -1,0 +1,40 @@
+{
+    "project_info": {
+        "project_number": "",
+        "firebase_url": "",
+        "project_id": "",
+        "storage_bucket": ""
+    },
+    "client": [
+        {
+            "client_info": {
+                "mobilesdk_app_id": "empty",
+                "android_client_info": {
+                    "package_name": "com.grab.grazel.android.sample.free"
+                }
+            },
+            "oauth_client": [
+                {
+                    "client_id": "",
+                    "client_type": 3
+                }
+            ],
+            "api_key": [
+                {
+                    "current_key": ""
+                }
+            ],
+            "services": {
+                "appinvite_service": {
+                    "other_platform_oauth_client": [
+                        {
+                            "client_id": "",
+                            "client_type": 3
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "configuration_version": "1"
+}


### PR DESCRIPTION
## Proposed Changes
The existing variant sourceSet's `javaDirectories` does not seem to be detecting directories with buildType (e.g. `flavor1FreeDebug`). By switching over to using `manifestFile` path, it properly reflects the correct path.

## Testing

<!--- Please describe how you tested your changes. -->

## Issues Fixed