### PR TITLE
Add support for multiple flavored resoruce dirs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,7 +27,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "grab_bazel_common",
-    commit = "e328756776118308c7224ffec8aa99734f34815b",
+    commit = "fdcec09fbf9f7f700c689e816395e15c5c469bd6",
     remote = "https://github.com/grab/grab-bazel-common.git",
 )
 

--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ grazel {
         }
         bazelCommon {
             gitRepository {
-                commit = "e328756776118308c7224ffec8aa99734f34815b"
+                commit = "fdcec09fbf9f7f700c689e816395e15c5c469bd6"
                 remote = "https://github.com/grab/grab-bazel-common.git"
             }
             toolchains {

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/AndroidRules.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/AndroidRules.kt
@@ -132,7 +132,8 @@ internal fun StatementsBuilder.androidBinary(
     manifestValues: Map<String, String?> = mapOf(),
     enableDataBinding: Boolean = false,
     visibility: Visibility = Visibility.Public,
-    resources: List<Assignee> = emptyList(),
+    resourceFiles: List<Assignee> = emptyList(),
+    resources: Assignee? = null,
     resValuesData: ResValuesData,
     deps: List<BazelDependency>,
     assetsGlob: List<String> = emptyList(),
@@ -157,12 +158,13 @@ internal fun StatementsBuilder.androidBinary(
         if (enableDataBinding) {
             "enable_data_binding" `=` enableDataBinding.toString().capitalize()
         }
-        resources.notEmpty {
-            "resource_files" `=` resources.joinToString(
+        resourceFiles.notEmpty {
+            "resource_files" `=` resourceFiles.joinToString(
                 separator = " + ",
                 transform = Assignee::asString
             )
         }
+        resources?.let { "resources" `=` resources }
         deps.notEmpty {
             "deps" `=` array(deps.map(BazelDependency::toString).quote)
         }
@@ -185,6 +187,7 @@ internal fun StatementsBuilder.androidLibrary(
     manifest: String? = null,
     srcsGlob: List<String> = emptyList(),
     visibility: Visibility = Visibility.Public,
+    resources: Assignee? = null,
     resourceFiles: List<Assignee> = emptyList(),
     enableDataBinding: Boolean = false,
     deps: List<BazelDependency>,
@@ -209,6 +212,7 @@ internal fun StatementsBuilder.androidLibrary(
                 transform = Assignee::asString
             )
         }
+        resources?.let { "resources" `=` resources }
         deps.notEmpty {
             "deps" `=` array(deps.map(BazelDependency::toString).map(String::quote))
         }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/starlark/Object.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/starlark/Object.kt
@@ -50,17 +50,19 @@ fun StatementsBuilder.obj(
  */
 fun Map<*, *>.toObject(
     quoteKeys: Boolean = false,
-    quoteValues: Boolean = false
+    quoteValues: Boolean = false,
+    allowEmpty: Boolean = false,
 ): ObjectStatement = obj {
     filterValues { it != null }.forEach { (orgKey, orgValue) ->
         val key = if (quoteKeys) orgKey!!.quote else orgKey.toString()
 
         when (orgValue) {
             is Map<*, *> -> {
-                if (orgValue.isNotEmpty()) {
+                if (orgValue.isNotEmpty() || allowEmpty) {
                     key `=` orgValue.toObject(quoteKeys, quoteValues)
                 }
             }
+
             else -> {
                 val value = if (quoteValues) orgValue!!.quote else orgValue!!
                 key `=` value

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidData.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidData.kt
@@ -24,7 +24,6 @@ internal interface AndroidData {
     val srcs: List<String>
     val res: List<String>
     val resValuesData: ResValuesData
-    val extraRes: List<ResourceSet>
     val assets: List<String>
     val assetsDir: String?
     val manifestFile: String?
@@ -46,7 +45,6 @@ internal data class AndroidLibraryData(
     override val srcs: List<String> = emptyList(),
     override val res: List<String> = emptyList(),
     override val resValuesData: ResValuesData = ResValuesData(),
-    override val extraRes: List<ResourceSet> = emptyList(),
     override val assets: List<String> = emptyList(),
     override val assetsDir: String? = null,
     override val manifestFile: String? = null,
@@ -64,7 +62,6 @@ internal data class AndroidBinaryData(
     override val srcs: List<String> = emptyList(),
     override val res: List<String> = emptyList(),
     override val resValuesData: ResValuesData = ResValuesData(),
-    override val extraRes: List<ResourceSet> = emptyList(),
     override val assets: List<String> = emptyList(),
     override val assetsDir: String? = null,
     override val manifestFile: String? = null,

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidInstrumentationBinaryTarget.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidInstrumentationBinaryTarget.kt
@@ -37,12 +37,10 @@ internal data class AndroidInstrumentationBinaryTarget(
     val resources: List<String>,
     val resourceStripPrefix: String? = null,
     val resourceFiles: List<String>,
-    val customResourceSets: List<ResourceSet> = emptyList(),
     val testInstrumentationRunner: String? = null,
 ) : BazelBuildTarget {
 
     override fun statements(builder: StatementsBuilder) = builder {
-        val resFiles = buildResources(name, resourceFiles, customResourceSets)
         androidInstrumentationBinary(
             name = name,
             srcsGlob = srcs,
@@ -55,7 +53,7 @@ internal data class AndroidInstrumentationBinaryTarget(
             manifestValues = manifestValues,
             resources = resources,
             resourceStripPrefix = resourceStripPrefix,
-            resourceFiles = resFiles,
+            resourceFiles = buildResFiles(resourceFiles),
             testInstrumentationRunner = testInstrumentationRunner,
         )
     }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidTarget.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidTarget.kt
@@ -27,9 +27,8 @@ import com.grab.grazel.migrate.BazelBuildTarget
 internal interface AndroidTarget : BazelBuildTarget {
     val enableDataBinding: Boolean
     val projectName: String
-    val res: List<String>
+    val resDirs: List<String>
     val resValuesData: ResValuesData
-    val customResourceSets: List<ResourceSet>
     val buildConfigData: BuildConfigData
     val packageName: String
     val manifest: String?
@@ -45,9 +44,8 @@ internal data class AndroidLibraryTarget(
     override val visibility: Visibility = Visibility.Public,
     override val enableDataBinding: Boolean = false,
     override val projectName: String = name,
-    override val res: List<String>,
+    override val resDirs: List<String>,
     override val resValuesData: ResValuesData = ResValuesData(),
-    override val customResourceSets: List<ResourceSet> = emptyList(),
     override val buildConfigData: BuildConfigData = BuildConfigData(),
     override val packageName: String,
     override val manifest: String? = null,
@@ -55,14 +53,13 @@ internal data class AndroidLibraryTarget(
     override val assetsDir: String? = null
 ) : AndroidTarget {
     override fun statements(builder: StatementsBuilder) = builder {
-        val resourceFiles = buildResources(projectName, res, customResourceSets)
         androidLibrary(
             name = name,
             packageName = packageName,
             manifest = manifest,
             enableDataBinding = enableDataBinding,
             srcsGlob = srcs,
-            resourceFiles = resourceFiles,
+            resources = buildResources(resDirs),
             visibility = visibility,
             deps = deps,
             tags = tags,
@@ -82,9 +79,8 @@ internal data class AndroidBinaryTarget(
     override val visibility: Visibility = Visibility.Public,
     override val enableDataBinding: Boolean = false,
     override val projectName: String = name,
-    override val res: List<String>,
+    override val resDirs: List<String>,
     override val resValuesData: ResValuesData = ResValuesData(),
-    override val customResourceSets: List<ResourceSet> = emptyList(),
     override val buildConfigData: BuildConfigData = BuildConfigData(),
     override val packageName: String,
     override val manifest: String? = null,
@@ -100,8 +96,6 @@ internal data class AndroidBinaryTarget(
     val incrementalDexing: Boolean = false,
 ) : AndroidTarget {
     override fun statements(builder: StatementsBuilder) = builder {
-        val resourceFiles = buildResources(name, res, customResourceSets)
-
         androidBinary(
             name = name,
             crunchPng = crunchPng,
@@ -115,7 +109,7 @@ internal data class AndroidBinaryTarget(
             srcsGlob = srcs,
             manifest = manifest,
             manifestValues = manifestValues,
-            resources = resourceFiles,
+            resources = buildResources(resDirs),
             resValuesData = resValuesData,
             deps = deps,
             assetsGlob = assetsGlob,

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/internal/ProjectBazelFileBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/internal/ProjectBazelFileBuilder.kt
@@ -39,6 +39,7 @@ class ProjectBazelFileBuilder(
 
     override fun build() = statements {
         targetBuilders
+            .sortedBy(TargetBuilder::sortOrder)
             .filter { it.canHandle(project) }
             .flatMap { it.build(project) }
             .forEach { it.statements(this) }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/KotlinLibraryTarget.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/KotlinLibraryTarget.kt
@@ -22,8 +22,7 @@ import com.grab.grazel.bazel.starlark.BazelDependency
 import com.grab.grazel.bazel.starlark.StatementsBuilder
 import com.grab.grazel.migrate.BazelBuildTarget
 import com.grab.grazel.migrate.android.ResValuesData
-import com.grab.grazel.migrate.android.ResourceSet
-import com.grab.grazel.migrate.android.buildResources
+import com.grab.grazel.migrate.android.buildResFiles
 
 internal data class KotlinLibraryTarget(
     override val name: String,
@@ -35,7 +34,6 @@ internal data class KotlinLibraryTarget(
     val packageName: String? = null,
     val res: List<String>,
     val resValuesData: ResValuesData = ResValuesData(),
-    val customResourceSets: List<ResourceSet> = emptyList(),
     val manifest: String? = null,
     val plugins: List<BazelDependency> = emptyList(),
     val assetsGlob: List<String> = emptyList(),
@@ -43,7 +41,7 @@ internal data class KotlinLibraryTarget(
 ) : BazelBuildTarget {
 
     override fun statements(builder: StatementsBuilder) = builder {
-        val resourceFiles = buildResources(projectName, res, customResourceSets, resValuesData)
+        val resourceFiles = buildResFiles(res)
         ktLibrary(
             name = name,
             packageName = packageName,

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/KotlinProjectDataExtractor.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/KotlinProjectDataExtractor.kt
@@ -97,7 +97,7 @@ constructor(
                 { kotlin.srcDirs.asSequence() }
             }
 
-            SourceSetType.RESOURCES, SourceSetType.RESOURCES_CUSTOM -> {
+            SourceSetType.RESOURCES -> {
                 { resources.srcDirs.asSequence() }
             }
 

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/target/AndroidBinaryTargetBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/target/AndroidBinaryTargetBuilder.kt
@@ -118,9 +118,8 @@ constructor(
                     packageName = androidBinaryData.packageName,
                     manifest = androidLibraryData.manifestFile,
                     manifestValues = androidBinaryData.manifestValues,
-                    res = androidLibraryData.res,
+                    resDirs = androidLibraryData.res,
                     resValuesData = androidLibraryData.resValuesData,
-                    customResourceSets = androidLibraryData.extraRes,
                     assetsGlob = androidLibraryData.assets,
                     assetsDir = androidLibraryData.assetsDir,
                     buildConfigData = androidLibraryData.buildConfigData

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/target/AndroidLibraryTargetBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/target/AndroidLibraryTargetBuilder.kt
@@ -95,12 +95,11 @@ constructor(
 private fun AndroidLibraryData.toAndroidLibTarget() = AndroidLibraryTarget(
     name = name,
     srcs = srcs,
-    res = res,
+    resDirs = res,
     deps = deps,
     enableDataBinding = databinding,
     resValuesData = resValuesData,
     buildConfigData = buildConfigData,
-    customResourceSets = extraRes,
     packageName = packageName,
     manifest = manifestFile,
     assetsGlob = assets,

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/android/AndroidLibraryDataKtTest.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/android/AndroidLibraryDataKtTest.kt
@@ -82,39 +82,6 @@ class AndroidLibraryDataKtTest : GrazelPluginTest() {
     }
 
     @Test
-    fun `assert build resources converts all types of resources to statements`() {
-        val resources = listOf("src/res/values.xml")
-        val resValuesData = ResValuesData(mapOf("value" to "hello"))
-        val customResourceSet = listOf(
-            ResourceSet(
-                "res-debug",
-                "src/main/res-debug/values/strings.xml"
-            )
-        )
-        val targetName = "target"
-
-        // Setup
-        val statements = StatementsBuilder().buildResources(
-            targetName,
-            resources,
-            customResourceSet,
-            resValuesData
-        ).joinToString(separator = " + ", transform = Assignee::asString)
-
-        // Assert
-        assertTrue("custom_res is generated") {
-            statements.contains(
-                """ + custom_res(
-  target = "target",
-  dir_name = "res-debug",
-  resource_files = glob([
-    "src/main/res-debug/values/strings.xml",
-  ])"""
-            )
-        }
-    }
-
-    @Test
     fun `assert flavor specific res values are extracted`() {
         buildAndroidBinaryProject {
             buildTypes {

--- a/sample-android-flavor/BUILD.bazel
+++ b/sample-android-flavor/BUILD.bazel
@@ -14,11 +14,12 @@ android_library(
             "generated_value": "generated",
         },
     },
-    resource_files = glob([
-        "src/main/res/**",
-    ]) + glob([
-        "src/flavor1/res/values/strings.xml",
-    ]),
+    resources = {
+        "src/flavor1/res": {
+        },
+        "src/main/res": {
+        },
+    },
     visibility = [
         "//visibility:public",
     ],
@@ -46,11 +47,12 @@ android_library(
             "generated_value": "generated",
         },
     },
-    resource_files = glob([
-        "src/main/res/**",
-    ]) + glob([
-        "src/flavor1/res/values/strings.xml",
-    ]),
+    resources = {
+        "src/flavor1/res": {
+        },
+        "src/main/res": {
+        },
+    },
     visibility = [
         "//visibility:public",
     ],
@@ -78,11 +80,12 @@ android_library(
             "generated_value": "generated",
         },
     },
-    resource_files = glob([
-        "src/main/res/**",
-    ]) + glob([
-        "src/flavor2/res/values/strings.xml",
-    ]),
+    resources = {
+        "src/flavor2/res": {
+        },
+        "src/main/res": {
+        },
+    },
     visibility = [
         "//visibility:public",
     ],
@@ -110,11 +113,12 @@ android_library(
             "generated_value": "generated",
         },
     },
-    resource_files = glob([
-        "src/main/res/**",
-    ]) + glob([
-        "src/flavor2/res/values/strings.xml",
-    ]),
+    resources = {
+        "src/flavor2/res": {
+        },
+        "src/main/res": {
+        },
+    },
     visibility = [
         "//visibility:public",
     ],

--- a/sample-android-flavor/src/main/java/com/grab/grazel/android/flavor/FlavorActivity.kt
+++ b/sample-android-flavor/src/main/java/com/grab/grazel/android/flavor/FlavorActivity.kt
@@ -25,13 +25,12 @@ import com.grab.grazel.android.flavor.databinding.ActivityFlavorBinding
 class FlavorActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val binding = DataBindingUtil
-            .setContentView<ActivityFlavorBinding>(
-                this,
-                R.layout.activity_flavor
-            )
+        val binding = DataBindingUtil.setContentView<ActivityFlavorBinding>(
+            this,
+            R.layout.activity_flavor
+        )
         findViewById<TextView>(R.id.text).text = HelloFlavorMessage().message(this)
-        findViewById<TextView>(R.id.text2).text = "With dep from ${ModuleName().name()}"
-        binding.viewModel = ViewModel("Text set from Binding adapter")
+        findViewById<TextView>(R.id.text2).text = "Flavored JVM class: ${ModuleName().name()}"
+        binding.viewModel = ViewModel("Text set via Binding adapter")
     }
 }

--- a/sample-android-flavor/src/main/res/layout/activity_flavor.xml
+++ b/sample-android-flavor/src/main/res/layout/activity_flavor.xml
@@ -27,7 +27,8 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:padding="16dp">
 
         <TextView
             android:id="@+id/text"

--- a/sample-android/BUILD.bazel
+++ b/sample-android/BUILD.bazel
@@ -49,13 +49,15 @@ android_binary(
     multidex = "native",
     res_values = {
         "strings": {
-            "generated_value": "important-key",
+            "generated_value": "This string was generated with resValue",
             "type": "debug",
             "flavor": "free",
         },
     },
     resource_files = glob([
         "src/main/res/**",
+    ]) + glob([
+        "src/free/res/values/strings.xml",
     ]) + custom_res(
         dir_name = "res-debug",
         resource_files = glob([
@@ -134,7 +136,7 @@ android_binary(
     multidex = "native",
     res_values = {
         "strings": {
-            "generated_value": "important-key",
+            "generated_value": "This string was generated with resValue",
             "type": "debug",
             "flavor": "paid",
         },
@@ -219,13 +221,15 @@ android_binary(
     multidex = "native",
     res_values = {
         "strings": {
-            "generated_value": "important-key",
+            "generated_value": "This string was generated with resValue",
             "type": "debug",
             "flavor": "free",
         },
     },
     resource_files = glob([
         "src/main/res/**",
+    ]) + glob([
+        "src/free/res/values/strings.xml",
     ]) + custom_res(
         dir_name = "res-debug",
         resource_files = glob([
@@ -304,7 +308,7 @@ android_binary(
     multidex = "native",
     res_values = {
         "strings": {
-            "generated_value": "important-key",
+            "generated_value": "This string was generated with resValue",
             "type": "debug",
             "flavor": "paid",
         },

--- a/sample-android/BUILD.bazel
+++ b/sample-android/BUILD.bazel
@@ -143,6 +143,8 @@ android_binary(
     },
     resource_files = glob([
         "src/main/res/**",
+    ]) + glob([
+        "src/paid/res/values/strings.xml",
     ]) + custom_res(
         dir_name = "res-debug",
         resource_files = glob([
@@ -315,6 +317,8 @@ android_binary(
     },
     resource_files = glob([
         "src/main/res/**",
+    ]) + glob([
+        "src/paid/res/values/strings.xml",
     ]) + custom_res(
         dir_name = "res-debug",
         resource_files = glob([

--- a/sample-android/BUILD.bazel
+++ b/sample-android/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@grab_bazel_common//android/test:instrumentation.bzl", "android_instrumentation_binary")
 load("@grab_bazel_common//rules:defs.bzl", "android_binary")
-load("@grab_bazel_common//tools/custom_res:custom_res.bzl", "custom_res")
 load("@tools_android//tools/crashlytics:defs.bzl", "crashlytics_android_library")
 load("@tools_android//tools/googleservices:defs.bzl", "google_services_xml")
 
@@ -54,17 +53,14 @@ android_binary(
             "flavor": "free",
         },
     },
-    resource_files = glob([
-        "src/main/res/**",
-    ]) + glob([
-        "src/free/res/values/strings.xml",
-    ]) + custom_res(
-        dir_name = "res-debug",
-        resource_files = glob([
-            "src/main/res-debug/values/strings.xml",
-        ]),
-        target = "sample-android-flavor1-free-debug",
-    ),
+    resources = {
+        "src/main/res-debug": {
+        },
+        "src/free/res": {
+        },
+        "src/main/res": {
+        },
+    },
     visibility = [
         "//visibility:public",
     ],
@@ -141,17 +137,14 @@ android_binary(
             "flavor": "paid",
         },
     },
-    resource_files = glob([
-        "src/main/res/**",
-    ]) + glob([
-        "src/paid/res/values/strings.xml",
-    ]) + custom_res(
-        dir_name = "res-debug",
-        resource_files = glob([
-            "src/main/res-debug/values/strings.xml",
-        ]),
-        target = "sample-android-flavor1-paid-debug",
-    ),
+    resources = {
+        "src/main/res-debug": {
+        },
+        "src/paid/res": {
+        },
+        "src/main/res": {
+        },
+    },
     visibility = [
         "//visibility:public",
     ],
@@ -228,17 +221,14 @@ android_binary(
             "flavor": "free",
         },
     },
-    resource_files = glob([
-        "src/main/res/**",
-    ]) + glob([
-        "src/free/res/values/strings.xml",
-    ]) + custom_res(
-        dir_name = "res-debug",
-        resource_files = glob([
-            "src/main/res-debug/values/strings.xml",
-        ]),
-        target = "sample-android-flavor2-free-debug",
-    ),
+    resources = {
+        "src/main/res-debug": {
+        },
+        "src/free/res": {
+        },
+        "src/main/res": {
+        },
+    },
     visibility = [
         "//visibility:public",
     ],
@@ -315,17 +305,14 @@ android_binary(
             "flavor": "paid",
         },
     },
-    resource_files = glob([
-        "src/main/res/**",
-    ]) + glob([
-        "src/paid/res/values/strings.xml",
-    ]) + custom_res(
-        dir_name = "res-debug",
-        resource_files = glob([
-            "src/main/res-debug/values/strings.xml",
-        ]),
-        target = "sample-android-flavor2-paid-debug",
-    ),
+    resources = {
+        "src/main/res-debug": {
+        },
+        "src/paid/res": {
+        },
+        "src/main/res": {
+        },
+    },
     visibility = [
         "//visibility:public",
     ],

--- a/sample-android/build.gradle
+++ b/sample-android/build.gradle
@@ -39,7 +39,7 @@ android {
         buildConfigField("String", "SOME_STRING", "\"Something\"")
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
-        resValue "string", "generated_value", "important-key"
+        resValue "string", "generated_value", "This string was generated with resValue"
 
         manifestPlaceholders = [orientation: "portrait"]
     }

--- a/sample-android/src/free/res/values/strings.xml
+++ b/sample-android/src/free/res/values/strings.xml
@@ -1,5 +1,5 @@
-<!--
-  ~ Copyright 2022 Grabtaxi Holdings PTE LTD (GRAB)
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2023 Grabtaxi Holdings PTE LTD (GRAB)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -15,6 +15,5 @@
   -->
 
 <resources>
-    <string name="app_name">Grazel Sample</string>
-    <string name="open_flavor_activity">Open Another Activity</string>
+
 </resources>

--- a/sample-android/src/free/res/values/strings.xml
+++ b/sample-android/src/free/res/values/strings.xml
@@ -15,5 +15,5 @@
   -->
 
 <resources>
-    <string name="overidable_resource">Overridable resource - From free</string>
+    <string name="overridable_resource">Overridable resource - From free</string>
 </resources>

--- a/sample-android/src/main/java/com/grab/grazel/android/sample/MainActivity.kt
+++ b/sample-android/src/main/java/com/grab/grazel/android/sample/MainActivity.kt
@@ -20,6 +20,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.View
+import android.widget.Button
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import com.grab.grazel.android.flavor.FlavorActivity
@@ -55,11 +56,10 @@ class MainActivity : AppCompatActivity() {
             .factory()
             .create()
             .simpleDependency()
-        findViewById<View>(R.id.text).setOnClickListener {
-            val intent = Intent(this, FlavorActivity::class.java)
-            startActivity(intent)
-        }
         findViewById<TextView>(R.id.text).setText(R.string.generated_value)
+        findViewById<Button>(R.id.button).setOnClickListener {
+            startActivity(Intent(this, FlavorActivity::class.java))
+        }
 
         // Assert custom resource set import
         R.string.custom_resource_set

--- a/sample-android/src/main/res-debug/values/strings.xml
+++ b/sample-android/src/main/res-debug/values/strings.xml
@@ -16,4 +16,6 @@
 
 <resources>
     <string name="custom_resource_set">Debug</string>
+    <string name="overridable_resource">Overridable resource - From frees</string>
+    <color name="colorPrimary">#000000</color>
 </resources>

--- a/sample-android/src/main/res/layout/activity_main.xml
+++ b/sample-android/src/main/res/layout/activity_main.xml
@@ -26,9 +26,23 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Hello World from Grazel!"
+        app:layout_constraintBottom_toTopOf="@+id/button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed" />
+
+    <Button
+        android:id="@+id/button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/open_flavor_activity"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/text">
+
+    </Button>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample-android/src/main/res/layout/activity_main.xml
+++ b/sample-android/src/main/res/layout/activity_main.xml
@@ -50,7 +50,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:text="@string/overidable_resource"
+        android:text="@string/overridable_resource"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/sample-android/src/main/res/layout/activity_main.xml
+++ b/sample-android/src/main/res/layout/activity_main.xml
@@ -38,11 +38,22 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
         android:text="@string/open_flavor_activity"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/overridable_resource"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/text">
 
     </Button>
+
+    <TextView
+        android:id="@+id/overridable_resource"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/overidable_resource"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/button" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample-android/src/main/res/values/strings.xml
+++ b/sample-android/src/main/res/values/strings.xml
@@ -17,4 +17,5 @@
 <resources>
     <string name="app_name">Grazel Sample</string>
     <string name="open_flavor_activity">Open Another Activity</string>
+    <string name="overidable_resource">Overridable resource</string>
 </resources>

--- a/sample-android/src/main/res/values/strings.xml
+++ b/sample-android/src/main/res/values/strings.xml
@@ -17,5 +17,5 @@
 <resources>
     <string name="app_name">Grazel Sample</string>
     <string name="open_flavor_activity">Open Another Activity</string>
-    <string name="overidable_resource">Overridable resource</string>
+    <string name="overridable_resource">Overridable resource</string>
 </resources>

--- a/sample-android/src/paid/res/values/strings.xml
+++ b/sample-android/src/paid/res/values/strings.xml
@@ -15,5 +15,5 @@
   -->
 
 <resources>
-    <string name="overidable_resource">Overridable resource - From free</string>
+    <string name="overidable_resource">Overridable resource - From paid</string>
 </resources>


### PR DESCRIPTION
- Changes to support `resources` API implemented in https://github.com/grab/grab-bazel-common/pull/89.
- Delete all custom resource set handling as it will now be handled automatically part of the rule.
- Add flavored sources sample