### PR TITLE
Don't add duplicate load statements when symbols are imported multiple times in `WORKSPACE`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,8 +50,6 @@ DAGGER_TAG = "2.37"
 
 DAGGER_SHA = "0f001ed38ed4ebc6f5c501c20bd35a68daf01c8dbd7541b33b7591a84fcc7b1c"
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
 http_archive(
     name = "dagger",
     sha256 = DAGGER_SHA,
@@ -61,7 +59,6 @@ http_archive(
 
 load("@dagger//:workspace_defs.bzl", "DAGGER_ARTIFACTS", "DAGGER_REPOSITORIES")
 load("@grab_bazel_common//:workspace_defs.bzl", "GRAB_BAZEL_COMMON_ARTIFACTS")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_jvm_external",
@@ -151,8 +148,6 @@ android_ndk_repository(
     name = "androidndk",
     api_level = 30,
 )
-
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "tools_android",

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/internal/WorkspaceBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/internal/WorkspaceBuilder.kt
@@ -92,7 +92,7 @@ internal class WorkspaceBuilder(
     private val mavenInstall get() = grazelExtension.rules.mavenInstall
     private val hasDatabinding = gradleProjectInfo.hasDatabinding
 
-    override fun build() = statements(loadStrategy = LoadStrategy.Inline) {
+    override fun build() = statements(loadStrategy = LoadStrategy.Inline()) {
         workspace(name = rootProject.name)
 
         kotlinRules()

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/bazel/starlark/LoadStrategyTest.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/bazel/starlark/LoadStrategyTest.kt
@@ -22,13 +22,34 @@ class LoadStrategyTest {
 
     @Test
     fun `assert inline load statements are added for INLINE strategy`() {
-        val statements = testStatements(loadStrategy = Inline)
+        val statements = testStatements(loadStrategy = Inline())
         assertEquals(8, statements.size)
         assertTrue("Load statements are added inline") {
             arrayOf(0, 4).all { index ->
                 statements[index].let { it is FunctionStatement && it.name == "load" }
             }
         }
+    }
+
+
+    @Test
+    fun `assert no duplicates are added for INLINE strategy`() {
+        val statements = statements(Inline()) {
+            load(":test.bzl", "test_lib")
+            load(":test.bzl", "test_lib")
+            load(":test.bzl", "test_lib", "test_bin")
+        }
+        assertEquals(
+            """
+                load(":test.bzl",  "test_lib")
+                
+                load(":test.bzl",  "test_bin")
+                
+                
+                """.trimIndent(),
+            statements.asString(),
+            "No duplicates are added for inline strategy"
+        )
     }
 
     @Test

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/KotlinWorkspaceRulesTest.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/KotlinWorkspaceRulesTest.kt
@@ -24,6 +24,7 @@ import com.grab.grazel.di.DaggerGrazelComponent
 import com.grab.grazel.gradle.ANDROID_LIBRARY_PLUGIN
 import com.grab.grazel.gradle.KOTLIN_ANDROID_PLUGIN
 import com.grab.grazel.migrate.internal.WorkspaceBuilder
+import com.grab.grazel.util.truth
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.repositories
@@ -70,14 +71,12 @@ class KotlinWorkspaceRulesTest {
             .create(listOf(rootProject, subProject))
             .build()
             .asString()
-        Truth.assertThat(workspaceStatements).apply {
+        workspaceStatements.truth().apply {
             // Default http archive
             contains(
                 """http_archive(
   name = "io_bazel_rules_kotlin","""
             )
-
-            // Compiler
             contains(
                 """
                     KOTLIN_VERSION = "$kotlinTag"


### PR DESCRIPTION
## Proposed Changes

Adapt `Inline` strategy to prevent import duplicates.