### PR TITLE
Use sets in maven rules and prepare support multiple maven install artifact pinning

### DIFF
--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/starlark/Functions.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/starlark/Functions.kt
@@ -83,14 +83,9 @@ fun StatementsBuilder.load(bzlFile: String, vararg symbols: String) {
  * load("@maven//:defs.bzl", default_pinned_maven_install = "pinned_maven_install")
  * ```
  */
-fun StatementsBuilder.load(path: String, assignmentBuilder: AssignmentBuilder.() -> Unit = {}) {
+fun StatementsBuilder.load(bzlFile: String, assignmentBuilder: AssignmentBuilder.() -> Unit = {}) {
     val symbolImports = Assignments(assignmentBuilder = assignmentBuilder)
-    add(
-        FunctionStatement(
-            name = "load",
-            params = listOf(path.quote.toStatement()) + symbolImports
-        )
-    )
+    loadStrategy.load(this, bzlFile, symbolImports.asString())
 }
 
 

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/starlark/Functions.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/starlark/Functions.kt
@@ -22,7 +22,7 @@ import java.io.PrintWriter
 
 data class FunctionStatement(
     val name: String,
-    private val params: List<AssignStatement>,
+    private val params: List<Assignee>,
     private val multilineParams: Boolean = false
 ) : Assignee {
     override fun write(level: Int, writer: PrintWriter) {
@@ -74,6 +74,25 @@ fun StatementsBuilder.function(name: String, vararg args: String) {
 fun StatementsBuilder.load(bzlFile: String, vararg symbols: String) {
     loadStrategy.load(this, bzlFile, *symbols)
 }
+
+/**
+ * Load statement with option to alias imported symbol via `assignmentBuilder`
+ *
+ * Eg:
+ * ```
+ * load("@maven//:defs.bzl", default_pinned_maven_install = "pinned_maven_install")
+ * ```
+ */
+fun StatementsBuilder.load(path: String, assignmentBuilder: AssignmentBuilder.() -> Unit = {}) {
+    val symbolImports = Assignments(assignmentBuilder = assignmentBuilder)
+    add(
+        FunctionStatement(
+            name = "load",
+            params = listOf(path.quote.toStatement()) + symbolImports
+        )
+    )
+}
+
 
 @Suppress("unused")
 fun StatementsBuilder.glob(include: ArrayStatement): FunctionStatement {

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/internal/WorkspaceBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/internal/WorkspaceBuilder.kt
@@ -140,14 +140,15 @@ internal class WorkspaceBuilder(
 
         val repositories = repositoryDataSource.supportedRepositories
             .map { repo ->
-                val passwordCredentials = if (grazelExtension.rules.mavenInstall.includeCredentials) {
-                    try {
-                        repo.getCredentials(PasswordCredentials::class.java)
-                    } catch (e: Exception) {
-                        // We only support basic auth now
-                        null
-                    }
-                } else null
+                val passwordCredentials =
+                    if (grazelExtension.rules.mavenInstall.includeCredentials) {
+                        try {
+                            repo.getCredentials(PasswordCredentials::class.java)
+                        } catch (e: Exception) {
+                            // We only support basic auth now
+                            null
+                        }
+                    } else null
                 DefaultMavenRepository(
                     repo.url.toString(),
                     passwordCredentials?.username,
@@ -167,16 +168,16 @@ internal class WorkspaceBuilder(
         jvmRules(
             rulesJvmExternalRule = mavenInstall.repository,
             artifacts = allArtifacts,
-            mavenRepositories = (repositories).distinct().toList(),
-            externalArtifacts = externalArtifacts.toList(),
-            externalRepositories = externalRepositories.toList(),
+            mavenRepositories = repositories.toSet(),
+            externalArtifacts = externalArtifacts.toSet(),
+            externalRepositories = externalRepositories.toSet(),
             jetify = jetifierData.isEnabled,
             jetifyIncludeList = jetifierData.includeList,
             failOnMissingChecksum = false,
             artifactPinning = artifactsPinner.isEnabled,
             mavenInstallJson = artifactsPinner.mavenInstallJson(),
             resolveTimeout = mavenInstall.resolveTimeout,
-            excludeArtifacts = mavenInstall.excludeArtifacts.get(),
+            excludeArtifacts = mavenInstall.excludeArtifacts.get().toSet(),
             overrideTargets = mavenInstall.overrideTargetLabels.get(),
             versionConflictPolicy = mavenInstall.versionConflictPolicy,
         )

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/bazel/starlark/LoadStrategyTest.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/bazel/starlark/LoadStrategyTest.kt
@@ -101,5 +101,25 @@ load(":test.bzl",  "d",  "a",  "t")
             message = "Load statements are sorted based on file name"
         )
     }
+
+    @Test
+    fun `assert aliases load statements are handled with load stategy`() {
+        val statements = statements {
+            load(":test.bzl") {
+                "pinned_maven_install" `=` "pinned_maven_install".quote
+            }
+            statements {
+                load(":test.bzl") {
+                    "pinned_maven_install" `=` "pinned_maven_install".quote
+                }
+            }
+        }
+        assertEquals(
+            expected = statements.asString(),
+            actual = """load(":test.bzl",  "pinned_maven_install = "pinned_maven_install"")
+""",
+            message = "Load statement aliases are handled with load strategy"
+        )
+    }
 }
 


### PR DESCRIPTION
Add ability to specify alias in `load` statement like `load("@maven//:defs.bzl", maven_pinned_maven_install = "pinned_maven_install")`