### PR TITLE
Make formatting tasks cacheable

### DIFF
--- a/constants.gradle
+++ b/constants.gradle
@@ -15,7 +15,7 @@
  */
 ext {
     groupId = "com.grab.grazel"
-    versionName = project.hasProperty("versionName") ? versionName : "0.4.1-alpha.13-rd"
+    versionName = project.hasProperty("versionName") ? versionName : "0.4.1-alpha.13"
 
     website = "https://grab.github.io/Grazel/"
 }

--- a/constants.gradle
+++ b/constants.gradle
@@ -15,7 +15,7 @@
  */
 ext {
     groupId = "com.grab.grazel"
-    versionName = project.hasProperty("versionName") ? versionName : "0.4.1-alpha.13"
+    versionName = project.hasProperty("versionName") ? versionName : "0.4.1-alpha.13-rd"
 
     website = "https://grab.github.io/Grazel/"
 }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/starlark/BazelDependency.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/starlark/BazelDependency.kt
@@ -19,7 +19,10 @@ package com.grab.grazel.bazel.starlark
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
 
-sealed class BazelDependency {
+sealed class BazelDependency : Comparable<BazelDependency> {
+
+    override fun compareTo(other: BazelDependency) = toString().compareTo(other.toString())
+
     data class ProjectDependency(
         val dependencyProject: Project,
         val suffix: String = "",

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/di/GrazelComponent.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/di/GrazelComponent.kt
@@ -54,7 +54,12 @@ import dagger.Lazy
 import dagger.Module
 import dagger.Provides
 import org.gradle.api.Project
+import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.model.ObjectFactory
+import org.gradle.configurationcache.extensions.serviceOf
 import org.gradle.kotlin.dsl.the
+import org.gradle.process.ExecOperations
 import javax.inject.Singleton
 
 @Component(
@@ -133,6 +138,20 @@ internal interface GrazelModule {
         @Provides
         @Singleton
         fun GrazelExtension.provideMavenInstallExtension() = rules.mavenInstall
+
+        // Added to satisfy dagger expectation of having all bindings available when @Inject is used
+        // For usage, actual instance derived from Gradle API must be used
+        @Provides
+        fun @receiver:RootProject Project.exec(): ExecOperations = serviceOf()
+
+        @Provides
+        fun @receiver:RootProject Project.objects(): ObjectFactory = serviceOf()
+
+        @Provides
+        fun @receiver:RootProject Project.layout(): ProjectLayout = serviceOf()
+
+        @Provides
+        fun @receiver:RootProject Project.fileSystemOperation(): FileSystemOperations = serviceOf()
     }
 }
 

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidExtractor.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidExtractor.kt
@@ -34,7 +34,7 @@ import com.grab.grazel.gradle.variant.AndroidVariantDataSource
 import com.grab.grazel.gradle.variant.MatchedVariant
 import com.grab.grazel.gradle.variant.getMigratableBuildVariants
 import com.grab.grazel.gradle.variant.nameSuffix
-import com.grab.grazel.migrate.android.PathResolveMode.*
+import com.grab.grazel.migrate.android.PathResolveMode.DIRECTORY
 import com.grab.grazel.migrate.android.SourceSetType.ASSETS
 import com.grab.grazel.migrate.android.SourceSetType.JAVA_KOTLIN
 import com.grab.grazel.migrate.android.SourceSetType.RESOURCES
@@ -139,7 +139,7 @@ constructor(
             compose = project.hasCompose,
             buildConfigData = extension.extractBuildConfig(this, matchedVariant.variant),
             resValuesData = extension.extractResValue(matchedVariant),
-            deps = deps,
+            deps = deps.sorted(),
             tags = tags
         )
     }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidInstrumentationBinaryDataExtractor.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidInstrumentationBinaryDataExtractor.kt
@@ -134,7 +134,7 @@ internal class DefaultAndroidInstrumentationBinaryDataExtractor
             customPackage = customPackage,
             targetPackage = matchedVariant.variant.applicationId.split(".test").first(),
             debugKey = debugKey,
-            deps = deps,
+            deps = deps.sorted(),
             instruments = BazelDependency.StringDependency(
                 ":${name}${matchedVariant.nameSuffix}"
             ),

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/dependencies/ClasspathReduction.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/dependencies/ClasspathReduction.kt
@@ -18,10 +18,9 @@ package com.grab.grazel.migrate.dependencies
 
 import com.grab.grazel.bazel.starlark.BazelDependency
 
-fun List<BazelDependency>.calculateDirectDependencyTags(self: String): List<String> =
-    filterIsInstance<BazelDependency.ProjectDependency>()
-        .map { "@direct${it}" }
-        .toMutableList()
-        .also {
-            it.add("@self//$self")
-        }
+fun List<BazelDependency>.calculateDirectDependencyTags(self: String) = asSequence()
+    .filterIsInstance<BazelDependency.ProjectDependency>()
+    .map { "@direct${it}" }
+    .toMutableList()
+    .also { it.add("@self//$self") }
+    .sorted()

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/FormatBazelBuildFileTask.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/FormatBazelBuildFileTask.kt
@@ -16,79 +16,145 @@
 
 package com.grab.grazel.tasks.internal
 
-import com.grab.grazel.util.BUILDIFIER
 import com.grab.grazel.util.BUILD_BAZEL
 import com.grab.grazel.util.WORKSPACE
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.support.serviceOf
 import org.gradle.process.ExecOperations
-import java.io.File
+import javax.inject.Inject
 
-private const val FORMAT_BAZEL_FILE_TASK = "formatBazelScripts"
-private const val FORMAT_BUILD_BAZEL_FILE_TASK = "formatBuildBazel"
-private const val FORMAT_WORK_SPACE_FILE_TASK = "formatWorkSpace"
-
-abstract class FormatBazelFileTask : DefaultTask() {
-
-    @get:OutputFile
-    var bazelFile: File = File(project.projectDir, BUILD_BAZEL)
+@CacheableTask
+internal open class FormatBazelFileTask
+@Inject
+constructor(
+    objectFactory: ObjectFactory,
+    private val execOperations: ExecOperations,
+    private val fileSystemOperations: FileSystemOperations,
+    private val projectLayout: ProjectLayout,
+) : DefaultTask() {
 
     @get:InputFile
-    abstract val buildifierScript: RegularFileProperty
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    val inputFile: RegularFileProperty = objectFactory.fileProperty()
 
-    init {
-        outputs.upToDateWhen { false } // This task is supposed to run always until we figure out up-to-date checks
-    }
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    val buildifierScript: RegularFileProperty = objectFactory.fileProperty()
 
-    private val execOperations: ExecOperations = project.serviceOf()
+    @get:OutputFile
+    val outputFile: RegularFileProperty = objectFactory.fileProperty()
 
     @TaskAction
     fun action() {
-        if (bazelFile.exists()) {
+        val input = inputFile.get().asFile
+        if (input.exists()) {
+            // Create a temp file to not touch the original file
+            val tmpFile = projectLayout
+                .buildDirectory
+                .file("grazel/${input.name}.tmp")
+                .get()
+                .asFile
+            fileSystemOperations.copy {
+                from(input)
+                into(tmpFile.parentFile)
+                rename { tmpFile.name }
+            }
             execOperations.exec {
                 commandLine = listOf(
                     buildifierScript.get().asFile.absolutePath,
-                    bazelFile.absolutePath
+                    tmpFile.absolutePath,
                 )
+            }
+            val formattedFile = outputFile.get().asFile
+            fileSystemOperations.copy {
+                from(tmpFile)
+                into(formattedFile.parentFile)
+                rename { formattedFile.name }
             }
         }
     }
 
     companion object {
-        private const val TASK_DESCRIPTION = "Format Bazel build files"
+        private const val FORMAT_BAZEL_FILE_TASK = "formatBazelScripts"
+        private const val FORMAT_BUILD_BAZEL_FILE_TASK = "formatBuildBazel"
+        private const val FORMAT_WORK_SPACE_FILE_TASK = "formatWorkSpace"
 
-        private fun Project.register(
-            taskName: String,
-            buildifierScriptProvider: Provider<RegularFile> =
-                objects.fileProperty().convention(
-                    rootProject.layout.buildDirectory.file(BUILDIFIER)
-                ),
-            configureAction: FormatBazelFileTask.() -> Unit
-        ): TaskProvider<out Task> {
-            return tasks.register<FormatBazelFileTask>(name = taskName).apply {
-                configure {
-                    group = GRAZEL_TASK_GROUP
-                    buildifierScript.set(buildifierScriptProvider)
-                    configureAction(this)
-                }
+        private fun FormatBazelFileTask.configureConventions(
+            buildifierScriptProvider: Provider<RegularFile>
+        ) {
+            group = GRAZEL_TASK_GROUP
+            buildifierScript.set(buildifierScriptProvider)
+        }
+
+        fun registerRootFormattingTasks(
+            project: Project,
+            buildifierScriptProvider: Provider<RegularFile>,
+            workspaceFormattingTask: FormatBazelFileTask.() -> Unit,
+            rootBuildBazelTask: FormatBazelFileTask.() -> Unit,
+        ): List<TaskProvider<out Task>> {
+            require(project == project.rootProject) {
+                "Can only register root formatting tasks on root project"
             }
+            val result = mutableListOf<TaskProvider<out Task>>()
+            val objects = project.serviceOf<ObjectFactory>()
+            val exec = project.serviceOf<ExecOperations>()
+            val fileSystem = project.serviceOf<FileSystemOperations>()
+            val layout = project.serviceOf<ProjectLayout>()
+            project.tasks.register<FormatBazelFileTask>(
+                FORMAT_WORK_SPACE_FILE_TASK,
+                objects, exec, fileSystem, layout
+            ).apply {
+                configure {
+                    description = "Format $WORKSPACE file"
+                    configureConventions(buildifierScriptProvider)
+                    outputFile.set(
+                        project
+                            .objects
+                            .fileProperty()
+                            .apply { set(project.file(WORKSPACE)) }
+                    )
+                    workspaceFormattingTask(this)
+                }
+            }.let(result::add)
+
+            project.tasks.register<FormatBazelFileTask>(
+                FORMAT_BUILD_BAZEL_FILE_TASK,
+                objects, exec, fileSystem, layout
+            ).apply {
+                configure {
+                    description = "Format $BUILD_BAZEL file"
+                    configureConventions(buildifierScriptProvider)
+                    outputFile.set(
+                        project
+                            .objects
+                            .fileProperty()
+                            .apply { set(project.file(BUILD_BAZEL)) }
+                    )
+                    rootBuildBazelTask(this)
+                }
+            }.let(result::add)
+
+            return result
         }
 
         /**
          * Register formatting task on the given project and provide callbacks to configure it.
-         *
-         * Based on the project type i.e whether root or subproject, register the correct formatting task and provide
-         * callbacks to configure it.
          *
          * @param project The project instance to register for
          * @param configureAction Callback to configure the registered task. Can be called multiple times for all registered
@@ -98,42 +164,25 @@ abstract class FormatBazelFileTask : DefaultTask() {
         fun register(
             project: Project,
             buildifierScriptProvider: Provider<RegularFile>,
-            configureAction: Task.() -> Unit
+            configureAction: FormatBazelFileTask.() -> Unit
         ): TaskProvider<out Task> {
-            val rootProject = project.rootProject
-            if (project == rootProject) {
-                // Format work space
-                val formatWorkspace = rootProject.register(
-                    taskName = FORMAT_WORK_SPACE_FILE_TASK,
-                    buildifierScriptProvider = buildifierScriptProvider,
-                ) {
-                    bazelFile = File(rootProject.projectDir, WORKSPACE)
-                    description = "Format $WORKSPACE file"
-
-                    configureAction(this)
-                }
-                // Format build.bazel
-                val formatBuildBazel = rootProject.register(
-                    taskName = FORMAT_BUILD_BAZEL_FILE_TASK,
-                    buildifierScriptProvider = buildifierScriptProvider,
-                ) {
+            require(project != project.rootProject) {
+                "Can only register formatting tasks on non-root project"
+            }
+            val objects = project.serviceOf<ObjectFactory>()
+            val exec = project.serviceOf<ExecOperations>()
+            val fileSystem = project.serviceOf<FileSystemOperations>()
+            val layout = project.serviceOf<ProjectLayout>()
+            return project.tasks.register<FormatBazelFileTask>(
+                FORMAT_BAZEL_FILE_TASK,
+                objects, exec, fileSystem, layout
+            ).apply {
+                configure {
                     description = "Format $BUILD_BAZEL file"
-
-                    configureAction(this)
-                }
-                // Aggregating task to depend on above
-                return rootProject.register(
-                    taskName = FORMAT_BAZEL_FILE_TASK,
-                ) {
-                    description = TASK_DESCRIPTION
-                    dependsOn(formatWorkspace, formatBuildBazel)
-                }
-            } else {
-                return project.register(
-                    taskName = FORMAT_BAZEL_FILE_TASK,
-                    buildifierScriptProvider = buildifierScriptProvider,
-                ) {
-                    description = TASK_DESCRIPTION
+                    configureConventions(buildifierScriptProvider)
+                    outputFile.set(project.objects.fileProperty().apply {
+                        set(project.file(BUILD_BAZEL))
+                    })
                     configureAction(this)
                 }
             }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/GenerateBuildifierScriptTask.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/GenerateBuildifierScriptTask.kt
@@ -16,8 +16,8 @@
 
 package com.grab.grazel.tasks.internal
 
-import com.grab.grazel.di.qualifiers.RootProject
 import com.grab.grazel.bazel.exec.bazelCommand
+import com.grab.grazel.di.qualifiers.RootProject
 import com.grab.grazel.util.BUILDIFIER
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/util/Constants.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/util/Constants.kt
@@ -24,8 +24,10 @@ internal const val BAZEL_CLEAN_TASK_NAME = "bazelClean"
 
 // BAZEL FILE NAMES
 internal const val WORKSPACE = "WORKSPACE"
+internal const val BAZEL_IGNORE = ".bazelignore"
+internal const val WORKSPACE_IGNORE = "WORKSPACE$BAZEL_IGNORE"
 internal const val BUILD_BAZEL = "BUILD.bazel"
-internal const val BUILD_BAZEL_IGNORE = "BUILD.bazelignore"
+internal const val BUILD_BAZEL_IGNORE = "BUILD$BAZEL_IGNORE"
 
 // Buildifier FILE NAME
 internal const val BUILDIFIER = "buildifier"


### PR DESCRIPTION
## Proposed Changes

Makes all formatting tasks i.e `FormatBazelFileTask` cacheable i.e they will only rerun if anything changed in the project's generated build scripts.

Work towards #59 

Changes

- Use property and providers instead of `dependsOn`
- Using same file as input and output to a task is wonky in gradle, so instead generate raw unformatted file to `build` and then generate final formatted script in project directoy.
- Fixed determinism issue in generated Android rules by sorting `deps`


<img width="1168" alt="Screenshot 2023-07-29 at 4 27 41 PM" src="https://github.com/grab/Grazel/assets/3940492/c4a38731-0a6a-4368-b8be-a030f9e2aeea">

