### PR TITLE
Run artifact pinning only when it enabled via extension

### DIFF
--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/dependencies/MavenInstallArtifactsCalculator.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/dependencies/MavenInstallArtifactsCalculator.kt
@@ -122,7 +122,7 @@ constructor(
                 artifactPinning = mavenInstallExtension.artifactPinning.enabled.get(),
                 versionConflictPolicy = mavenInstallExtension.versionConflictPolicy,
                 mavenInstallJson = mavenInstallJson.name,
-                isMavenInstallJsonEnabled = mavenInstallJson.exists()
+                isMavenInstallJsonEnabled = mavenInstallExtension.artifactPinning.enabled.get() && mavenInstallJson.exists()
             )
         }
 

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/TasksManager.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/TasksManager.kt
@@ -123,13 +123,15 @@ constructor(
             dependsOn(postScriptGenerateTask)
             dependsOn(rootFormattingTasks.all)
             dependsOn(projectBazelFormattingTasks)
-            dependsOn(pinArtifactsTask)
             configure {
-                // Inside a configure block since GrazelExtension won't be configured yet if
+                // Inside a configure block since GrazelExtension won't be configured yet and if
                 // we write it as part of plugin application and all extension value would
                 // have default value instead of user configured value.
                 if (grazelComponent.extension().android.features.dataBindingMetaData) {
                     dependsOn(dataBindingMetaDataTask)
+                }
+                if (grazelComponent.extension().rules.mavenInstall.artifactPinning.enabled.get()) {
+                    dependsOn(pinArtifactsTask)
                 }
             }
         }


### PR DESCRIPTION
## Proposed Changes

Configure pinning task and other pinning related work only when enabled via `GrazelExtension`