### PR TITLE
Ensure test variant extends from their base variant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .idea/gradle.xml
 .idea/misc.xml
 .idea/modules.xml
+.idea/migrations.xml
 .idea/vcs.xml
 .idea/workspace.xml
 .idea/compiler.xml

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/gradle/variant/AndroidVariants.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/gradle/variant/AndroidVariants.kt
@@ -45,10 +45,13 @@ class AndroidVariant(
             add(backingVariant.buildType.name)
             if (variantType.isTest) {
                 add(TEST_VARIANT)
-                if (variantType.isAndroidTest) add(ANDROID_TEST_VARIANT)
+                add(baseVariantName)
+                if (variantType.isAndroidTest) {
+                    add(ANDROID_TEST_VARIANT)
+                }
                 add(backingVariant.buildType.name + variantType.testSuffix)
             }
-        }.filter { it != name }.toSet()
+        }.filter { it != name && it.trim().isNotEmpty() }.toSet()
     }
 
     override val compileConfiguration get() = setOf(backingVariant.compileConfiguration)
@@ -65,6 +68,11 @@ class AndroidVariant(
         .add("name", name)
         .add("variantType", variantType)
         .toString()
+
+    private val baseVariantName: String
+        get() = (backingVariant.flavorName + backingVariant.buildType.name.capitalize()).replaceFirstChar {
+            if (it.isUpperCase()) it.toLowerCase().toString() else it.toString()
+        }
 }
 
 /**

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/gradle/variant/VariantTest.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/gradle/variant/VariantTest.kt
@@ -95,9 +95,10 @@ class VariantTest {
         androidVariant(appExtension.testVariants.first()).let { androidTestVariant ->
             assertThat(androidTestVariant.extendsFrom).containsExactly(
                 "default",
-                "debug",
                 "paid",
+                "debug",
                 "test",
+                "paidDebug",
                 "androidTest",
                 "debugAndroidTest"
             )
@@ -105,9 +106,10 @@ class VariantTest {
         androidVariant(appExtension.unitTestVariants.first()).let { unitTestVariant ->
             assertThat(unitTestVariant.extendsFrom).containsExactly(
                 "default",
-                "debug",
                 "paid",
+                "debug",
                 "test",
+                "paidDebug",
                 "debugUnitTest"
             )
         }


### PR DESCRIPTION
## Proposed Changes

Ensure `{variant}androidTest` and `{variant}UnitTest` have extends from `{variant}`. This reduces no of `maven_install` generated decreasing duplication.