### PR TITLE
Use gradle files API instead of Java file API

### DIFF
--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/ComputeWorkspaceDependenciesTask.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/ComputeWorkspaceDependenciesTask.kt
@@ -34,7 +34,6 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.register
-import java.io.File
 
 @CacheableTask
 abstract class ComputeWorkspaceDependenciesTask : DefaultTask() {
@@ -65,10 +64,7 @@ abstract class ComputeWorkspaceDependenciesTask : DefaultTask() {
             val computeTask = rootProject.tasks
                 .register<ComputeWorkspaceDependenciesTask>(TASK_NAME) {
                     workspaceDependencies.set(
-                        File(
-                            rootProject.buildDir,
-                            "grazel/mergedDependencies.json"
-                        )
+                        rootProject.layout.buildDirectory.file("grazel/mergedDependencies.json")
                     )
                 }
             ResolveVariantDependenciesTask.register(

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/ResolveVariantDependenciesTask.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/ResolveVariantDependenciesTask.kt
@@ -49,8 +49,8 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
-import java.io.File
-import java.util.*
+import java.util.TreeMap
+import java.util.TreeSet
 import kotlin.streams.asSequence
 
 @CacheableTask
@@ -250,10 +250,9 @@ internal abstract class ResolveVariantDependenciesTask : DefaultTask() {
 
             }
 
-            val resolvedDependenciesJson = File(
-                project.buildDir,
-                "grazel/${variant.name}/dependencies.json"
-            )
+            val resolvedDependenciesJson = project.layout
+                .buildDirectory
+                .file("grazel/${variant.name}/dependencies.json")
 
             val resolveVariantDependenciesTask = project.tasks
                 .register<ResolveVariantDependenciesTask>(


### PR DESCRIPTION
## Proposed Changes

Use gradle file API to setup File properties. For some unknown reason this was causing a Stack overflow error only on Linux. It could be due to how paths are resolved but root cause is unclear.

Attaching stacktrace for discoverability in case any body else stumbles upon this.


```java
* Exception is:
java.lang.StackOverflowError
	at org.gradle.api.internal.provider.ValueSupplier$PlusProducer.visitProducerTasks(ValueSupplier.java:162)
	at org.gradle.api.internal.provider.ValueSupplier$PlusProducer.visitProducerTasks(ValueSupplier.java:162)
	at org.gradle.api.internal.provider.ValueSupplier$PlusProducer.visitProducerTasks(ValueSupplier.java:162)
	at org.gradle.api.internal.provider.ValueSupplier$PlusProducer.visitProducerTasks(ValueSupplier.java:162)
	at org.gradle.api.internal.provider.ValueSupplier$PlusProducer.visitProducerTasks(ValueSupplier.java:162)
	at org.gradle.api.internal.provider.ValueSupplier$PlusProducer.visitProducerTasks(ValueSupplier.java:162)
	at org.gradle.api.internal.provider.ValueSupplier$PlusProducer.visitProducerTasks(ValueSupplier.java:162)
	at org.gradle.api.internal.provider.ValueSupplier$PlusProducer.visitProducerTasks(ValueSupplier.java:162)
	at org.gradle.api.internal.provider.ValueSupplier$PlusProducer.visitProducerTasks(ValueSupplier.java:162)
	at org.gradle.api.internal.provider.ValueSupplier$PlusProducer.visitProducerTasks(ValueSupplier.java:162)
	at org.gradle.api.internal.provider.ValueSupplier$PlusProducer.visitProducerTasks(ValueSupplier.java:162)
	at org.gradle.api.internal.provider.ValueSupplier$PlusProducer.visitProducerTasks(ValueSupplier.java:162)

```