### PR TITLE
Don't use calculated dependency graph for gradle project info

### DIFF
--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/gradle/GradleProjectInfo.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/gradle/GradleProjectInfo.kt
@@ -79,8 +79,8 @@ internal class DefaultGradleProjectInfo(
     }
 
     override val hasGooglePlayServices: Boolean by lazy {
-        projectGraph
-            .nodes()
+        rootProject
+            .subprojects
             .any { project -> project.hasCrashlytics || project.hasGooglePlayServicesPlugin }
     }
 }


### PR DESCRIPTION
- Detected race condition internally causing builds to be non deterministic, need to revisit later with better lazy and task up to date compatible dependency graph calculation