### PR TITLE
Allow changing versionName via project property for CI releases

### DIFF
--- a/constants.gradle
+++ b/constants.gradle
@@ -15,7 +15,7 @@
  */
 ext {
     groupId = "com.grab.grazel"
-    versionName = "0.4.1-alpha.24"
+    versionName = project.hasProperty("versionName") ? versionName : "0.4.1-alpha.25"
 
     website = "https://grab.github.io/Grazel/"
 }


### PR DESCRIPTION
## Proposed Changes
We used to be able to change the `versionName` via project property and this allows our internal CI to be able to properly publish via dynamically altering the `versionName`. But it seems to be removed since #121.

This PR is to restore the ability to alter `versionName` via project properties

## Testing

<!--- Please describe how you tested your changes. -->

## Issues Fixed