### PR TITLE
Generate `resource_configuration_filters` for `android_binary` targets and update lint baseline

### DIFF
--- a/.bazel/.test.bazelrc
+++ b/.bazel/.test.bazelrc
@@ -3,4 +3,3 @@ test --build_tests_only
 test --test_verbose_timeout_warnings
 test --test_output=errors # Print test logs for failed tests
 test --test_summary=terse # Print information only about unsuccessful tests that were run
-test --ui_event_filters=-DEBUG

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,7 +27,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "grab_bazel_common",
-    commit = "7ce14f2063b19b1e700bb9fa51cc944626545450",
+    commit = "46e70d673d86c1aae4b317f05506601b19c2b4c9",
     remote = "https://github.com/grab/grab-bazel-common.git",
 )
 

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ grazel {
     rules {
         bazelCommon {
             gitRepository {
-                commit = "7ce14f2063b19b1e700bb9fa51cc944626545450"
+                commit = "46e70d673d86c1aae4b317f05506601b19c2b4c9"
                 remote = "https://github.com/grab/grab-bazel-common.git"
             }
             toolchains {

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/AndroidRules.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/AndroidRules.kt
@@ -140,6 +140,7 @@ internal fun StatementsBuilder.androidBinary(
     assetsDir: String? = null,
     buildConfigData: BuildConfigData,
     lintConfigs: LintConfigs? = null,
+    resConfigFilters: Set<String> = emptySet(),
 ) {
     load("@$GRAB_BAZEL_COMMON//rules:defs.bzl", "android_binary")
     rule("android_binary") {
@@ -167,6 +168,9 @@ internal fun StatementsBuilder.androidBinary(
                 separator = " + ",
                 transform = Assignee::asString
             )
+        }
+        resConfigFilters.notEmpty {
+            "resource_configuration_filters" `=` resConfigFilters.quote
         }
         resources?.let { "resources" `=` resources }
         deps.notEmpty {

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidData.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidData.kt
@@ -80,6 +80,7 @@ internal data class AndroidBinaryData(
     override val tags: List<String> = emptyList(),
     override val lintConfigs: LintConfigs,
     val manifestValues: Map<String, String?> = emptyMap(),
+    val resConfigs: Set<String> = emptySet(),
     val multidex: Multidex = Multidex.Native,
     val dexShards: Int? = null,
     val incrementalDexing: Boolean = true,

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidExtractor.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidExtractor.kt
@@ -220,6 +220,11 @@ constructor(
 
         val lintConfigs = lintConfigs(extension.lintOptions, project)
 
+        val resourceConfiguration = matchedVariant.variant
+            .productFlavors
+            .flatMap { it.resourceConfigurations }
+            .toSortedSet()
+
         return AndroidBinaryData(
             name = project.name,
             manifestValues = manifestValues,
@@ -234,6 +239,7 @@ constructor(
             compose = project.hasCompose,
             databinding = project.hasDatabinding,
             lintConfigs = lintConfigs,
+            resConfigs = resourceConfiguration
         )
     }
 }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidTarget.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidTarget.kt
@@ -103,6 +103,7 @@ internal data class AndroidBinaryTarget(
     val debugKey: String? = null,
     val dexShards: Int? = null,
     val manifestValues: Map<String, String?> = mapOf(),
+    val resConfigFilters: Set<String> = emptySet(),
     val customPackage: String,
     val incrementalDexing: Boolean = false,
 ) : AndroidTarget {
@@ -121,6 +122,7 @@ internal data class AndroidBinaryTarget(
             srcsGlob = srcs,
             manifest = manifest,
             manifestValues = manifestValues,
+            resConfigFilters = resConfigFilters,
             resources = buildResources(resDirs),
             resValuesData = resValuesData,
             deps = deps,

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/target/AndroidBinaryTargetBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/target/AndroidBinaryTargetBuilder.kt
@@ -119,6 +119,7 @@ constructor(
                     packageName = androidBinaryData.packageName,
                     manifest = androidLibraryData.manifestFile,
                     manifestValues = androidBinaryData.manifestValues,
+                    resConfigFilters = androidBinaryData.resConfigs,
                     resDirs = androidLibraryData.res,
                     resValuesData = androidLibraryData.resValuesData,
                     assetsGlob = androidLibraryData.assets,

--- a/sample-android-flavor/src/main/res/layout/activity_flavor.xml
+++ b/sample-android-flavor/src/main/res/layout/activity_flavor.xml
@@ -34,7 +34,8 @@
             android:id="@+id/text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center" />
+            android:layout_gravity="center"
+            android:lineHeight="12dp" />
 
         <TextView
             android:id="@+id/text2"
@@ -47,6 +48,11 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             app:text="@{viewModel}" />
+
+        <ImageView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:src="@android:color/background_dark"></ImageView>
 
     </LinearLayout>
 </layout>

--- a/sample-android/BUILD.bazel
+++ b/sample-android/BUILD.bazel
@@ -56,6 +56,19 @@ android_binary(
             "flavor": "free",
         },
     },
+    resource_configuration_filters = [
+        "en",
+        "id",
+        "in",
+        "ja",
+        "km",
+        "ko",
+        "ms",
+        "my",
+        "th",
+        "vi",
+        "zh",
+    ],
     resources = {
         "src/main/res-debug": {
         },
@@ -147,6 +160,19 @@ android_binary(
             "flavor": "paid",
         },
     },
+    resource_configuration_filters = [
+        "en",
+        "id",
+        "in",
+        "ja",
+        "km",
+        "ko",
+        "ms",
+        "my",
+        "th",
+        "vi",
+        "zh",
+    ],
     resources = {
         "src/main/res-debug": {
         },
@@ -238,6 +264,19 @@ android_binary(
             "flavor": "free",
         },
     },
+    resource_configuration_filters = [
+        "en",
+        "id",
+        "in",
+        "ja",
+        "km",
+        "ko",
+        "ms",
+        "my",
+        "th",
+        "vi",
+        "zh",
+    ],
     resources = {
         "src/main/res-debug": {
         },
@@ -329,6 +368,19 @@ android_binary(
             "flavor": "paid",
         },
     },
+    resource_configuration_filters = [
+        "en",
+        "id",
+        "in",
+        "ja",
+        "km",
+        "ko",
+        "ms",
+        "my",
+        "th",
+        "vi",
+        "zh",
+    ],
     resources = {
         "src/main/res-debug": {
         },

--- a/sample-android/build.gradle
+++ b/sample-android/build.gradle
@@ -66,19 +66,24 @@ android {
     }
 
     flavorDimensions "service", "release"
+    def resConfigs = ["en", "id", "in", "km", "ms", "my", "th", "vi", "zh", "ko", "ja"]
     productFlavors {
         flavor1 {
+            resourceConfigurations += resConfigs
             dimension "service"
         }
         flavor2 {
+            resourceConfigurations += resConfigs
             dimension "service"
         }
         free {
+            resourceConfigurations += resConfigs
             dimension "release"
             applicationIdSuffix ".free"
             resValue("string", "flavor", "free")
         }
         paid {
+            resourceConfigurations += resConfigs
             dimension "release"
             applicationIdSuffix ".paid"
             resValue("string", "flavor", "paid")

--- a/sample-android/lint_baseline.xml
+++ b/sample-android/lint_baseline.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.4.0-alpha09" type="baseline" client="" dependencies="true" name="" variant="all" version="8.4.0-alpha09">
+<issues format="6" by="lint 8.5.0-alpha02" type="baseline" client="" dependencies="true" name="" variant="all" version="8.5.0-alpha02">
+
+    <issue
+        id="LocaleFolder"
+        message="The locale folder &quot;`id`&quot; should be called &quot;`in`&quot; instead; see the `java.util.Locale` documentation">
+        <location
+            file="../../../../android-armeabi-v7a-fastbuild/bin/sample-android/sample-android-flavor1-free-debug_res/out/res/values-id"/>
+    </issue>
+
+    <issue
+        id="MissingConstraints"
+        message="This view is not constrained vertically: at runtime it will jump to the top unless you add a vertical constraint"
+        errorLine1="    &lt;EditText"
+        errorLine2="     ~~~~~~~~">
+        <location
+            file="../../../../android-armeabi-v7a-fastbuild/bin/sample-android/sample-android-flavor1-free-debug_res/out/res/layout/activity_main.xml"
+            line="73"
+            column="6"/>
+    </issue>
 
     <issue
         id="DiscouragedApi"
@@ -35,12 +53,122 @@
     </issue>
 
     <issue
+        id="MissingTranslation"
+        message="&quot;generated_value&quot; is not translated in &quot;id&quot; (Indonesian)"
+        errorLine1="        &lt;string name=&quot;generated_value&quot;>This string was generated with resValue&lt;/string>"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../../../../android-armeabi-v7a-fastbuild/bin/sample-android/src/main/res/values/gen_strings_sample-android-flavor1-free-debug_res_value.xml"
+            line="3"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;type&quot; is not translated in &quot;id&quot; (Indonesian)"
+        errorLine1="        &lt;string name=&quot;type&quot;>debug&lt;/string>"
+        errorLine2="                ~~~~~~~~~~~">
+        <location
+            file="../../../../android-armeabi-v7a-fastbuild/bin/sample-android/src/main/res/values/gen_strings_sample-android-flavor1-free-debug_res_value.xml"
+            line="4"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;flavor&quot; is not translated in &quot;id&quot; (Indonesian)"
+        errorLine1="        &lt;string name=&quot;flavor&quot;>free&lt;/string>"
+        errorLine2="                ~~~~~~~~~~~~~">
+        <location
+            file="../../../../android-armeabi-v7a-fastbuild/bin/sample-android/src/main/res/values/gen_strings_sample-android-flavor1-free-debug_res_value.xml"
+            line="5"
+            column="17"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;app_name&quot; is not translated in &quot;id&quot; (Indonesian)"
+        errorLine1="&lt;string name=&quot;app_name&quot;>Grazel Sample&lt;/string>"
+        errorLine2="        ~~~~~~~~~~~~~~~">
+        <location
+            file="../../../../android-armeabi-v7a-fastbuild/bin/sample-android/sample-android-flavor1-free-debug_res/out/res/values/values.xml"
+            line="14"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;custom_resource_set&quot; is not translated in &quot;id&quot; (Indonesian)"
+        errorLine1="&lt;string name=&quot;custom_resource_set&quot;>Debug&lt;/string>"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../../../../android-armeabi-v7a-fastbuild/bin/sample-android/sample-android-flavor1-free-debug_res/out/res/values/values.xml"
+            line="17"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;open_compose_activity&quot; is not translated in &quot;id&quot; (Indonesian)"
+        errorLine1="&lt;string name=&quot;open_compose_activity&quot;>Open Compose Activity&lt;/string>"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../../../../android-armeabi-v7a-fastbuild/bin/sample-android/sample-android-flavor1-free-debug_res/out/res/values/values.xml"
+            line="20"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;open_flavor_activity&quot; is not translated in &quot;id&quot; (Indonesian)"
+        errorLine1="&lt;string name=&quot;open_flavor_activity&quot;>Open Another Activity&lt;/string>"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../../../../android-armeabi-v7a-fastbuild/bin/sample-android/sample-android-flavor1-free-debug_res/out/res/values/values.xml"
+            line="21"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;overridable_resource&quot; is not translated in &quot;id&quot; (Indonesian)"
+        errorLine1="&lt;string name=&quot;overridable_resource&quot;>Overridable resource - From frees&lt;/string>"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../../../../android-armeabi-v7a-fastbuild/bin/sample-android/sample-android-flavor1-free-debug_res/out/res/values/values.xml"
+            line="24"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="MissingTranslation"
+        message="&quot;title_activity_compose&quot; is not translated in &quot;id&quot; (Indonesian)"
+        errorLine1="&lt;string name=&quot;title_activity_compose&quot;>ComposeActivity&lt;/string>"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../../../../android-armeabi-v7a-fastbuild/bin/sample-android/sample-android-flavor1-free-debug_res/out/res/values/values.xml"
+            line="27"
+            column="9"/>
+    </issue>
+
+    <issue
         id="Typos"
         message="Did you mean &quot;flavor!&quot; instead of &quot;flavor1&quot;?">
         <location
             file="../sample-android-flavor-flavor1-free-debug_res/out/res/values/values.xml"
             line="5"
             column="37"/>
+    </issue>
+
+    <issue
+        id="ExtraTranslation"
+        message="&quot;overridable_resource1&quot; is translated here but not found in default locale"
+        errorLine1="&lt;string name=&quot;overridable_resource1&quot;>Overridable resource - From free&lt;/string>"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../../../../android-armeabi-v7a-fastbuild/bin/sample-android/sample-android-flavor1-free-debug_res/out/res/values-id/values.xml"
+            line="5"
+            column="9"/>
     </issue>
 
     <issue
@@ -66,6 +194,17 @@
     </issue>
 
     <issue
+        id="UnusedResources"
+        message="The resource `R.string.overridable_resource1` appears to be unused"
+        errorLine1="&lt;string name=&quot;overridable_resource1&quot;>Overridable resource - From free&lt;/string>"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../../../../android-armeabi-v7a-fastbuild/bin/sample-android/sample-android-flavor1-free-debug_res/out/res/values-id/values.xml"
+            line="5"
+            column="9"/>
+    </issue>
+
+    <issue
         id="MonochromeLauncherIcon"
         message="The application adaptive icon is missing a monochrome tag"
         errorLine1="&lt;adaptive-icon xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
@@ -85,6 +224,48 @@
             file="../../../../android-armeabi-v7a-fastbuild/bin/sample-android/sample-android-flavor1-free-debug_res/out/res/mipmap-anydpi-v26/ic_launcher_round.xml"
             line="17"
             column="1"/>
+    </issue>
+
+    <issue
+        id="TextFields"
+        message="This text field does not specify an `inputType`"
+        errorLine1="    &lt;EditText"
+        errorLine2="     ~~~~~~~~">
+        <location
+            file="../../../../android-armeabi-v7a-fastbuild/bin/sample-android/sample-android-flavor1-free-debug_res/out/res/layout/activity_main.xml"
+            line="73"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="Autofill"
+        message="Missing `autofillHints` attribute"
+        errorLine1="    &lt;EditText"
+        errorLine2="     ~~~~~~~~">
+        <location
+            file="../../../../android-armeabi-v7a-fastbuild/bin/sample-android/sample-android-flavor1-free-debug_res/out/res/layout/activity_main.xml"
+            line="73"
+            column="6"/>
+    </issue>
+
+    <issue
+        id="ContentDescription"
+        message="Missing `contentDescription` attribute on image">
+        <location
+            file="../sample-android-flavor-flavor1-free-debug_res/out/res/layout/activity_flavor.xml"
+            line="52"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="LabelFor"
+        message="Missing accessibility label: provide either a view with an `android:labelFor` that references this view or provide an `android:hint`"
+        errorLine1="    &lt;EditText"
+        errorLine2="     ~~~~~~~~">
+        <location
+            file="../../../../android-armeabi-v7a-fastbuild/bin/sample-android/sample-android-flavor1-free-debug_res/out/res/layout/activity_main.xml"
+            line="73"
+            column="6"/>
     </issue>
 
     <issue
@@ -116,7 +297,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="../../../../android-armeabi-v7a-fastbuild/bin/sample-android/sample-android-flavor1-free-debug_res/out/res/layout/activity_main.xml"
-            line="28"
+            line="29"
             column="9"/>
     </issue>
 

--- a/sample-android/src/free/res/values-id/strings.xml
+++ b/sample-android/src/free/res/values-id/strings.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2024 Grabtaxi Holdings PTE LTD (GRAB)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <string name="overridable_resource1">Overridable resource - From free</string>
+</resources>

--- a/sample-android/src/main/res/layout/activity_main.xml
+++ b/sample-android/src/main/res/layout/activity_main.xml
@@ -25,6 +25,7 @@
         android:id="@+id/text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:lineHeight="16dp"
         android:text="Hello World from Grazel!"
         app:layout_constraintBottom_toTopOf="@+id/button"
         app:layout_constraintEnd_toEndOf="parent"
@@ -68,5 +69,10 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/composeButton" />
+
+    <EditText
+        android:id="@+id/edit"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
- Update bazel common
- Generate `resource_configuration_filters`, related https://github.com/grab/grab-bazel-common/pull/161
- Regenerate lint baseline with samples for `MissingTranslation`