### PR TITLE
Implement direct dependency tags for maven external targets

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,9 @@ grazel {
                 languageVersion = "1.7"
                 jvmTarget = "17"
             }
+            // Enable to add tags in generated tags that can be used to do classpath reduction
+            // for build performance.
+            enabledTransitiveReduction = false
         }
         dagger {
             tag = "2.47"

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidExtractor.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidExtractor.kt
@@ -123,7 +123,14 @@ constructor(
             ?.let(::relativePath)
 
         val tags = if (grazelExtension.rules.kotlin.enabledTransitiveReduction) {
-            deps.calculateDirectDependencyTags(name)
+            val transitiveMavenDeps = dependenciesDataSource.collectTransitiveMavenDeps(
+                project = project,
+                buildGraphType = BuildGraphType(BUILD, matchedVariant.variant)
+            )
+            calculateDirectDependencyTags(
+                self = name,
+                deps = deps + transitiveMavenDeps
+            )
         } else emptyList()
 
         val lintConfigs = lintConfigs(extension.lintOptions, project)

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidUnitTestDataExtractor.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidUnitTestDataExtractor.kt
@@ -91,7 +91,11 @@ internal class DefaultAndroidUnitTestDataExtractor @Inject constructor(
             )
 
         val tags = if (kotlinExtension.enabledTransitiveReduction) {
-            deps.calculateDirectDependencyTags(name)
+            val transitiveMavenDeps = dependenciesDataSource.collectTransitiveMavenDeps(
+                project = project,
+                buildGraphType = BuildGraphType(ConfigurationScope.TEST, matchedVariant.variant)
+            )
+            calculateDirectDependencyTags(name, deps + transitiveMavenDeps)
         } else emptyList()
 
         return AndroidUnitTestData(

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/dependencies/ClasspathReduction.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/dependencies/ClasspathReduction.kt
@@ -17,10 +17,18 @@
 package com.grab.grazel.migrate.dependencies
 
 import com.grab.grazel.bazel.starlark.BazelDependency
+import com.grab.grazel.bazel.starlark.BazelDependency.MavenDependency
+import com.grab.grazel.bazel.starlark.BazelDependency.ProjectDependency
 
-fun List<BazelDependency>.calculateDirectDependencyTags(self: String) = asSequence()
-    .filterIsInstance<BazelDependency.ProjectDependency>()
-    .map { "@direct${it}" }
-    .toMutableList()
+fun calculateDirectDependencyTags(
+    self: String,
+    deps: List<BazelDependency>
+) = deps.asSequence().mapNotNull {
+    when (it) {
+        is ProjectDependency -> "@direct${it}"
+        is MavenDependency -> it.copy(repo = "maven").toString()
+        else -> null
+    }
+}.toMutableList()
     .also { it.add("@self//$self") }
     .sorted()

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/KotlinProjectDataExtractor.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/KotlinProjectDataExtractor.kt
@@ -72,7 +72,11 @@ internal class DefaultKotlinProjectDataExtractor
         ) + project.androidJarDeps() + project.kotlinParcelizeDeps()
 
         val tags = if (kotlinExtension.enabledTransitiveReduction) {
-            deps.calculateDirectDependencyTags(self = name)
+            val transitiveMavenDeps = dependenciesDataSource.collectTransitiveMavenDeps(
+                project = project,
+                buildGraphType = BuildGraphType(ConfigurationScope.BUILD)
+            )
+            calculateDirectDependencyTags(self = name, deps = deps + transitiveMavenDeps)
         } else emptyList()
 
         return KotlinProjectData(

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/KotlinUnitTestDataExtractor.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/KotlinUnitTestDataExtractor.kt
@@ -88,7 +88,11 @@ internal class DefaultKotlinUnitTestDataExtractor @Inject constructor(
         }
 
         val tags = if (kotlinExtension.enabledTransitiveReduction) {
-            deps.calculateDirectDependencyTags(name)
+            val transitiveMavenDeps = dependenciesDataSource.collectTransitiveMavenDeps(
+                project = project,
+                buildGraphType = BuildGraphType(ConfigurationScope.TEST)
+            )
+            calculateDirectDependencyTags(name, deps + transitiveMavenDeps)
         } else emptyList()
 
         return UnitTestData(

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/dependencies/ClasspathReductionTest.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/dependencies/ClasspathReductionTest.kt
@@ -1,0 +1,58 @@
+package com.grab.grazel.migrate.dependencies
+
+import com.grab.grazel.bazel.starlark.BazelDependency
+import com.grab.grazel.bazel.starlark.BazelDependency.MavenDependency
+import com.grab.grazel.bazel.starlark.BazelDependency.ProjectDependency
+import com.grab.grazel.buildProject
+import com.grab.grazel.util.truth
+import org.junit.Test
+
+class ClasspathReductionTest {
+    @Test
+    fun `test with project dependencies`() {
+        val rootProject = buildProject("root")
+        val subproject = buildProject("sub", parent = rootProject)
+        val deps: List<ProjectDependency> = listOf(
+            ProjectDependency(dependencyProject = rootProject),
+            ProjectDependency(dependencyProject = subproject),
+        )
+        calculateDirectDependencyTags("self", deps).truth {
+            containsExactly(
+                "@direct//root:root",
+                "@direct//sub:sub",
+                "@self//self"
+            )
+        }
+    }
+
+    @Test
+    fun `test with maven dependencies`() {
+        val deps: List<BazelDependency> = listOf(
+            MavenDependency(group = "com.example", name = "lib1"),
+            MavenDependency(group = "org.test", name = "lib2", repo = "custom_repo")
+        )
+        calculateDirectDependencyTags("self", deps).truth {
+            containsExactly(
+                "@maven//:com_example_lib1",
+                "@maven//:org_test_lib2",
+                "@self//self"
+            )
+        }
+    }
+
+    @Test
+    fun `test with mixed dependencies`() {
+        val rootProject = buildProject("root")
+        val deps: List<BazelDependency> = listOf(
+            ProjectDependency(dependencyProject = rootProject),
+            MavenDependency(group = "com.example", name = "lib1")
+        )
+        calculateDirectDependencyTags("self", deps).truth {
+            containsExactly(
+                "@direct//root:root",
+                "@maven//:com_example_lib1",
+                "@self//self",
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes

This change generates tags for maven artifacts that can be used to do classpath reduction on Bazel side. This builds on top of existing implementation where direct dependency information is embedded in tags and our Bazel fork uses it to do classpath reduction. 

#### Design Decisions

-  All maven targets irrespective of which classpath they are in `WORKSPACE`, have `@maven// prefix`. 
- Entire transitive classpath of each maven target is made direct since there are many dependencies internal that does not follow proper compile/runtime in their pom.xml. To overcome this, Grazel flattens this and adds them to tags. 

With this change, we can enable compiling with direct dependencies for both internal and external targets which brings significant performance increase for both clean and incremental builds.