### PR TITLE
Fix resource sets not handling manifests correctly

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,7 +27,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "grab_bazel_common",
-    commit = "93a0875d12a7e223221390505b04deff76ea3845",
+    commit = "9b0439127d50741c2f19d8df9932d6338f763dab",
     remote = "https://github.com/grab/grab-bazel-common.git",
 )
 
@@ -400,6 +400,7 @@ maven_install(
         "android.arch.lifecycle:livedata-core",
         "android.arch.lifecycle:runtime",
         "android.arch.lifecycle:viewmodel",
+        "androidx.fragment:fragment",
         "com.android.databinding:baseLibrary",
         "com.android.support:animated-vector-drawable",
         "com.android.support:cardview-v7",
@@ -413,7 +414,6 @@ maven_install(
         "com.android.support:support-compat",
         "com.android.support:support-core-ui",
         "com.android.support:support-core-utils",
-        "com.android.support:support-fragment",
         "com.android.support:support-vector-drawable",
         "com.android.support:versionedparcelable",
         "com.android.support:viewpager",

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ grazel {
     rules {
         bazelCommon {
             gitRepository {
-                commit = "93a0875d12a7e223221390505b04deff76ea3845"
+                commit = "9b0439127d50741c2f19d8df9932d6338f763dab"
                 remote = "https://github.com/grab/grab-bazel-common.git"
             }
             toolchains {

--- a/flavors/sample-android-flavor/BUILD.bazel
+++ b/flavors/sample-android-flavor/BUILD.bazel
@@ -28,7 +28,6 @@ android_library(
         },
         "main": {
             "res": "src/main/res",
-            "assets": "src/main/assets",
             "manifest": "src/main/AndroidManifest.xml",
         },
     },
@@ -71,7 +70,6 @@ android_library(
         },
         "main": {
             "res": "src/main/res",
-            "assets": "src/main/assets",
             "manifest": "src/main/AndroidManifest.xml",
         },
     },
@@ -117,7 +115,6 @@ android_library(
         },
         "main": {
             "res": "src/main/res",
-            "assets": "src/main/assets",
             "manifest": "src/main/AndroidManifest.xml",
         },
     },
@@ -160,7 +157,6 @@ android_library(
         },
         "main": {
             "res": "src/main/res",
-            "assets": "src/main/assets",
             "manifest": "src/main/AndroidManifest.xml",
         },
     },

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidData.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidData.kt
@@ -24,7 +24,10 @@ internal data class BazelSourceSet(
     val res: String?,
     val assets: String?,
     val manifest: String?,
-)
+) {
+    val isEmpty: Boolean = res == null && assets == null && manifest == null
+    val hasResources: Boolean = res != null || assets != null
+}
 
 internal interface AndroidData {
     val name: String

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidExtractor.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidExtractor.kt
@@ -112,8 +112,14 @@ constructor(
         val srcs = androidSources(migratableSourceSets, JAVA_KOTLIN).toList()
 
         val resourceSets = migratableSourceSets.flatMap { it.toResourceSet(project) }
+            .filterNot(BazelSourceSet::isEmpty)
             .reversed()
             .toSet()
+            .let { resourcesSets ->
+                if (resourcesSets.size == 1 && resourcesSets.all { !it.hasResources }) {
+                    emptySet()
+                } else resourcesSets
+            }
 
         val manifestFile = androidManifestParser
             .androidManifestFile(migratableSourceSets)

--- a/sample-android-library/BUILD.bazel
+++ b/sample-android-library/BUILD.bazel
@@ -4,6 +4,7 @@ android_library(
     name = "sample-android-library-demo-free-debug",
     srcs = glob([
         "src/main/java/com/grab/grazel/android/sample/SampleViewModel.kt",
+        "src/debug/kotlin/Empty.kt",
     ]),
     custom_package = "com.grab.grazel.android.sample.lib",
     enable_data_binding = True,
@@ -11,7 +12,15 @@ android_library(
         "enabled": True,
         "config": "//:lint.xml",
     },
-    manifest = "src/main/AndroidManifest.xml",
+    manifest = "src/debug/AndroidManifest.xml",
+    resource_sets = {
+        "debug": {
+            "manifest": "src/debug/AndroidManifest.xml",
+        },
+        "main": {
+            "manifest": "src/main/AndroidManifest.xml",
+        },
+    },
     visibility = [
         "//visibility:public",
     ],
@@ -24,6 +33,7 @@ android_library(
     name = "sample-android-library-demo-paid-debug",
     srcs = glob([
         "src/main/java/com/grab/grazel/android/sample/SampleViewModel.kt",
+        "src/debug/kotlin/Empty.kt",
     ]),
     custom_package = "com.grab.grazel.android.sample.lib",
     enable_data_binding = True,
@@ -31,7 +41,15 @@ android_library(
         "enabled": True,
         "config": "//:lint.xml",
     },
-    manifest = "src/main/AndroidManifest.xml",
+    manifest = "src/debug/AndroidManifest.xml",
+    resource_sets = {
+        "debug": {
+            "manifest": "src/debug/AndroidManifest.xml",
+        },
+        "main": {
+            "manifest": "src/main/AndroidManifest.xml",
+        },
+    },
     visibility = [
         "//visibility:public",
     ],
@@ -44,6 +62,7 @@ android_library(
     name = "sample-android-library-full-free-debug",
     srcs = glob([
         "src/main/java/com/grab/grazel/android/sample/SampleViewModel.kt",
+        "src/debug/kotlin/Empty.kt",
     ]),
     custom_package = "com.grab.grazel.android.sample.lib",
     enable_data_binding = True,
@@ -51,7 +70,15 @@ android_library(
         "enabled": True,
         "config": "//:lint.xml",
     },
-    manifest = "src/main/AndroidManifest.xml",
+    manifest = "src/debug/AndroidManifest.xml",
+    resource_sets = {
+        "debug": {
+            "manifest": "src/debug/AndroidManifest.xml",
+        },
+        "main": {
+            "manifest": "src/main/AndroidManifest.xml",
+        },
+    },
     visibility = [
         "//visibility:public",
     ],
@@ -64,6 +91,7 @@ android_library(
     name = "sample-android-library-full-paid-debug",
     srcs = glob([
         "src/main/java/com/grab/grazel/android/sample/SampleViewModel.kt",
+        "src/debug/kotlin/Empty.kt",
     ]),
     custom_package = "com.grab.grazel.android.sample.lib",
     enable_data_binding = True,
@@ -71,7 +99,15 @@ android_library(
         "enabled": True,
         "config": "//:lint.xml",
     },
-    manifest = "src/main/AndroidManifest.xml",
+    manifest = "src/debug/AndroidManifest.xml",
+    resource_sets = {
+        "debug": {
+            "manifest": "src/debug/AndroidManifest.xml",
+        },
+        "main": {
+            "manifest": "src/main/AndroidManifest.xml",
+        },
+    },
     visibility = [
         "//visibility:public",
     ],

--- a/sample-android-library/src/debug/AndroidManifest.xml
+++ b/sample-android-library/src/debug/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2022 Grabtaxi Holdings PTE LTD (GRAB)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<manifest package="com.grab.grazel.android.sample.lib" />

--- a/sample-android-library/src/debug/kotlin/Empty.kt
+++ b/sample-android-library/src/debug/kotlin/Empty.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Grabtaxi Holdings PTE LTD (GRAB)
+ * Copyright 2024 Grabtaxi Holdings PTE LTD (GRAB)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,9 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-ext {
-    groupId = "com.grab.grazel"
-    versionName = project.hasProperty("versionName") ? versionName : "0.4.2-alpha.03"
 
-    website = "https://grab.github.io/Grazel/"
-}

--- a/sample-android/lint_baseline.xml
+++ b/sample-android/lint_baseline.xml
@@ -5,7 +5,7 @@
         id="LocaleFolder"
         message="The locale folder &quot;`id`&quot; should be called &quot;`in`&quot; instead; see the `java.util.Locale` documentation">
         <location
-            file="../../../../armeabi-v7a-fastbuild-android-ST-5b74a929aefd/bin/sample-android/_sample-android-demo-free-debug_res/out/res/values-id"/>
+            file="../../../../arm64-v8a-fastbuild-android-ST-0b2165ce48ec/bin/sample-android/_sample-android-demo-free-debug_res/out/res/values-id"/>
     </issue>
 
     <issue
@@ -14,7 +14,7 @@
         errorLine1="    &lt;EditText"
         errorLine2="     ~~~~~~~~">
         <location
-            file="../../../../armeabi-v7a-fastbuild-android-ST-5b74a929aefd/bin/sample-android/_sample-android-demo-free-debug_res/out/res/layout/activity_main.xml"
+            file="../../../../arm64-v8a-fastbuild-android-ST-0b2165ce48ec/bin/sample-android/_sample-android-demo-free-debug_res/out/res/layout/activity_main.xml"
             line="73"
             column="6"/>
     </issue>
@@ -25,7 +25,7 @@
         errorLine1="            android:screenOrientation=&quot;${orientation}&quot; >"
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="../../../../armeabi-v7a-fastbuild-android-ST-5b74a929aefd/bin/sample-android/_sample-android-demo-free-debug_res/_merged/AndroidManifest.xml"
+            file="../../../../arm64-v8a-fastbuild-android-ST-0b2165ce48ec/bin/sample-android/_sample-android-demo-free-debug_res/_merged/AndroidManifest.xml"
             line="35"
             column="13"/>
     </issue>
@@ -36,7 +36,7 @@
         errorLine1="&lt;manifest xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
         errorLine2=" ~~~~~~~~">
         <location
-            file="../../../../armeabi-v7a-fastbuild-android-ST-5b74a929aefd/bin/sample-android/_sample-android-demo-free-debug_res/_merged/AndroidManifest.xml"
+            file="../../../../arm64-v8a-fastbuild-android-ST-0b2165ce48ec/bin/sample-android/_sample-android-demo-free-debug_res/_merged/AndroidManifest.xml"
             line="17"
             column="2"/>
     </issue>
@@ -47,7 +47,7 @@
         errorLine1="&lt;manifest xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
         errorLine2=" ~~~~~~~~">
         <location
-            file="../../../../armeabi-v7a-fastbuild-android-ST-5b74a929aefd/bin/sample-android/_sample-android-demo-free-debug_res/_merged/AndroidManifest.xml"
+            file="../../../../arm64-v8a-fastbuild-android-ST-0b2165ce48ec/bin/sample-android/_sample-android-demo-free-debug_res/_merged/AndroidManifest.xml"
             line="17"
             column="2"/>
     </issue>
@@ -67,7 +67,7 @@
         errorLine1="&lt;string name=&quot;overridable_resource1&quot;>Overridable resource - From free&lt;/string>"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="../../../../armeabi-v7a-fastbuild-android-ST-5b74a929aefd/bin/sample-android/_sample-android-demo-free-debug_res/out/res/values-id/values.xml"
+            file="../../../../arm64-v8a-fastbuild-android-ST-0b2165ce48ec/bin/sample-android/_sample-android-demo-free-debug_res/out/res/values-id/values.xml"
             line="5"
             column="9"/>
     </issue>
@@ -100,7 +100,7 @@
         errorLine1="        &lt;string name=&quot;type&quot;>debug&lt;/string>"
         errorLine2="                ~~~~~~~~~~~">
         <location
-            file="../../../../armeabi-v7a-fastbuild-android-ST-5b74a929aefd/bin/sample-android/src/main/res/values/gen_strings_sample-android-demo-free-debug_res_value.xml"
+            file="../../../../arm64-v8a-fastbuild-android-ST-0b2165ce48ec/bin/sample-android/src/main/res/values/gen_strings_sample-android-demo-free-debug_res_value.xml"
             line="4"
             column="17"/>
     </issue>
@@ -111,7 +111,7 @@
         errorLine1="        &lt;string name=&quot;flavor&quot;>free&lt;/string>"
         errorLine2="                ~~~~~~~~~~~~~">
         <location
-            file="../../../../armeabi-v7a-fastbuild-android-ST-5b74a929aefd/bin/sample-android/src/main/res/values/gen_strings_sample-android-demo-free-debug_res_value.xml"
+            file="../../../../arm64-v8a-fastbuild-android-ST-0b2165ce48ec/bin/sample-android/src/main/res/values/gen_strings_sample-android-demo-free-debug_res_value.xml"
             line="5"
             column="17"/>
     </issue>
@@ -122,7 +122,7 @@
         errorLine1="&lt;string name=&quot;overridable_resource1&quot;>Overridable resource - From free&lt;/string>"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="../../../../armeabi-v7a-fastbuild-android-ST-5b74a929aefd/bin/sample-android/_sample-android-demo-free-debug_res/out/res/values-id/values.xml"
+            file="../../../../arm64-v8a-fastbuild-android-ST-0b2165ce48ec/bin/sample-android/_sample-android-demo-free-debug_res/out/res/values-id/values.xml"
             line="5"
             column="9"/>
     </issue>
@@ -133,7 +133,7 @@
         errorLine1="&lt;adaptive-icon xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
         errorLine2="^">
         <location
-            file="../../../../armeabi-v7a-fastbuild-android-ST-5b74a929aefd/bin/sample-android/_sample-android-demo-free-debug_res/out/res/mipmap-anydpi-v26/ic_launcher.xml"
+            file="../../../../arm64-v8a-fastbuild-android-ST-0b2165ce48ec/bin/sample-android/_sample-android-demo-free-debug_res/out/res/mipmap-anydpi-v26/ic_launcher.xml"
             line="17"
             column="1"/>
     </issue>
@@ -144,7 +144,7 @@
         errorLine1="&lt;adaptive-icon xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;>"
         errorLine2="^">
         <location
-            file="../../../../armeabi-v7a-fastbuild-android-ST-5b74a929aefd/bin/sample-android/_sample-android-demo-free-debug_res/out/res/mipmap-anydpi-v26/ic_launcher_round.xml"
+            file="../../../../arm64-v8a-fastbuild-android-ST-0b2165ce48ec/bin/sample-android/_sample-android-demo-free-debug_res/out/res/mipmap-anydpi-v26/ic_launcher_round.xml"
             line="17"
             column="1"/>
     </issue>
@@ -155,7 +155,7 @@
         errorLine1="    &lt;EditText"
         errorLine2="     ~~~~~~~~">
         <location
-            file="../../../../armeabi-v7a-fastbuild-android-ST-5b74a929aefd/bin/sample-android/_sample-android-demo-free-debug_res/out/res/layout/activity_main.xml"
+            file="../../../../arm64-v8a-fastbuild-android-ST-0b2165ce48ec/bin/sample-android/_sample-android-demo-free-debug_res/out/res/layout/activity_main.xml"
             line="73"
             column="6"/>
     </issue>
@@ -166,7 +166,7 @@
         errorLine1="    &lt;EditText"
         errorLine2="     ~~~~~~~~">
         <location
-            file="../../../../armeabi-v7a-fastbuild-android-ST-5b74a929aefd/bin/sample-android/_sample-android-demo-free-debug_res/out/res/layout/activity_main.xml"
+            file="../../../../arm64-v8a-fastbuild-android-ST-0b2165ce48ec/bin/sample-android/_sample-android-demo-free-debug_res/out/res/layout/activity_main.xml"
             line="73"
             column="6"/>
     </issue>
@@ -177,7 +177,7 @@
         errorLine1="    &lt;EditText"
         errorLine2="     ~~~~~~~~">
         <location
-            file="../../../../armeabi-v7a-fastbuild-android-ST-5b74a929aefd/bin/sample-android/_sample-android-demo-free-debug_res/out/res/layout/activity_main.xml"
+            file="../../../../arm64-v8a-fastbuild-android-ST-0b2165ce48ec/bin/sample-android/_sample-android-demo-free-debug_res/out/res/layout/activity_main.xml"
             line="73"
             column="6"/>
     </issue>
@@ -206,7 +206,7 @@
         errorLine1="        android:text=&quot;Hello World from Grazel!&quot;"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="../../../../armeabi-v7a-fastbuild-android-ST-5b74a929aefd/bin/sample-android/_sample-android-demo-free-debug_res/out/res/layout/activity_main.xml"
+            file="../../../../arm64-v8a-fastbuild-android-ST-0b2165ce48ec/bin/sample-android/_sample-android-demo-free-debug_res/out/res/layout/activity_main.xml"
             line="29"
             column="9"/>
     </issue>


### PR DESCRIPTION
## Proposed Changes

Previously resource set was not handling cases where res/assets folders were empty and only manifest existed for a variant. In that case the manifest was completely skipped in the generated code, this fixes it by changing the logic to handle the empty assets/res directories.

Example
```kotlin
    resource_sets = {
        "debug": {
            "manifest": "src/debug/AndroidManifest.xml",
        },
        "main": {
            "manifest": "src/main/AndroidManifest.xml",
        },
    },
```

## Testing

Updated tests