### PR TITLE
Fix CI and add explicit setup for android sdk and bazel versions

### DIFF
--- a/.github/actions/android/action.yml
+++ b/.github/actions/android/action.yml
@@ -1,0 +1,16 @@
+name: 'Setup Android SDK'
+description: 'Installs Android SDK and necessary components for CI builds'
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v3
+      with:
+        accept-android-sdk-licenses: 'true'
+        log-accepted-android-sdk-licenses: 'false'
+        packages: 'platforms;android-34 build-tools;33.0.1 ndk;23.0.7599858 tools platform-tools'
+    - name: Add NDK to PATH
+      shell: bash
+      run: |
+        echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/23.0.7599858" >> $GITHUB_ENV
+        echo "$ANDROID_HOME/ndk/23.0.7599858" >> $GITHUB_PATH

--- a/.github/actions/bazel/action.yml
+++ b/.github/actions/bazel/action.yml
@@ -10,16 +10,23 @@ inputs:
 runs:
     using: "composite"
     steps:
+        -   name: Set Bazel version
+            shell: bash
+            run: echo "USE_BAZEL_VERSION=$(cat .bazelversion)" >> $GITHUB_ENV
+
         -   name: Setup Bazelisk
-            uses: bazelbuild/setup-bazelisk@v2
+            uses: bazelbuild/setup-bazelisk@v3
         -   name: Install JDK 17
-            uses: actions/setup-java@v3
+            uses: actions/setup-java@v4
             with:
                 distribution: "zulu"
                 java-version: "17"
 
+        -   name: Setup Android SDK
+            uses: ./.github/actions/android
+
         -   name: Mount bazel cache
-            uses: actions/cache@v3
+            uses: actions/cache@v4
             with:
                 path: "bazel-cache"
                 key: ${{ inputs.cache-key }}

--- a/.github/actions/gradle/action.yml
+++ b/.github/actions/gradle/action.yml
@@ -1,0 +1,37 @@
+name: 'Run Gradle with Cache'
+description: 'Configures Gradle environment with JDK, Android SDK, and cache setup'
+inputs:
+  job-id:
+    description: 'Unique identifier for the cache'
+    required: true
+  arguments:
+    description: 'Gradle command arguments to execute'
+    required: true
+  build-root-directory:
+    description: 'Root directory of the Gradle project'
+    default: '.'
+  read-only:
+    description: 'Whether to use read-only cache'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Install JDK 17
+      uses: actions/setup-java@v4
+      with:
+        distribution: "zulu"
+        java-version: "17"
+
+    - name: Setup Android SDK
+      uses: ./.github/actions/android
+
+    - name: Run Gradle with Cache
+      uses: burrunan/gradle-cache-action@v1.12
+      with:
+        debug: false
+        job-id: ${{ inputs.job-id }}
+        build-root-directory: ${{ inputs.build-root-directory }}
+        read-only: ${{ inputs.read-only }}
+        gradle-dependencies-cache-key: |
+          gradle/libs.versions.toml
+        arguments: ${{ inputs.arguments }} 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,77 +66,43 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v4
-            -   name: Install JDK 17
-                uses: actions/setup-java@v4
+            -   name: Run Gradle build
+                uses: ./.github/actions/gradle
                 with:
-                    distribution: "zulu"
-                    java-version: "17"
-            -   uses: burrunan/gradle-cache-action@v1.12
-                name: grazel-build
-                with:
-                    debug: false
                     job-id: grazel-build
-                    read-only: ${{ github.ref != 'refs/heads/master' }}
-                    gradle-dependencies-cache-key: |
-                        gradle/libs.versions.toml
                     arguments: assembleDebug --scan
+                    read-only: ${{ github.ref != 'refs/heads/master' }}
 
     grazel-test:
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v4
-            -   name: Install JDK 17
-                uses: actions/setup-java@v4
+            -   name: Run Gradle tests
+                uses: ./.github/actions/gradle
                 with:
-                    distribution: "zulu"
-                    java-version: "17"
-            -   uses: burrunan/gradle-cache-action@v1.12
-                name: grazel-test
-                with:
-                    debug: false
                     job-id: grazel-test
-                    read-only: ${{ github.ref != 'refs/heads/master' }}
-                    gradle-dependencies-cache-key: |
-                        gradle/libs.versions.toml
                     arguments: test --scan
+                    read-only: ${{ github.ref != 'refs/heads/master' }}
 
     grazel-gradle-plugin-test:
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v4
-            -   name: Install JDK 17
-                uses: actions/setup-java@v4
+            -   name: Test Gradle plugin
+                uses: ./.github/actions/gradle
                 with:
-                    distribution: "zulu"
-                    java-version: "17"
-            -   uses: burrunan/gradle-cache-action@v1.12
-                name: grazel-gradle-plugin-test
-                with:
-                    debug: false
                     job-id: grazel-gradle-plugin-test
                     build-root-directory: grazel-gradle-plugin
-                    read-only: ${{ github.ref != 'refs/heads/master' }}
-                    gradle-dependencies-cache-key: |
-                        gradle/libs.versions.toml
                     arguments: test --scan
+                    read-only: ${{ github.ref != 'refs/heads/master' }}
 
     migrate-to-bazel-validation:
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v4
-            -   name: Setup Bazelisk
-                uses: bazelbuild/setup-bazelisk@v2
-            -   name: Install JDK 17
-                uses: actions/setup-java@v3
+            -   name: Validate migration
+                uses: ./.github/actions/gradle
                 with:
-                    distribution: "zulu"
-                    java-version: "17"
-            -   uses: burrunan/gradle-cache-action@v1.12
-                name: migrate-to-bazel-validation
-                with:
-                    debug: false
                     job-id: migrate-to-bazel-validation
-                    read-only: ${{ github.ref != 'refs/heads/master' }}
-                    gradle-dependencies-cache-key: |
-                        gradle/libs.versions.toml
                     arguments: migrateToBazel --scan
+                    read-only: ${{ github.ref != 'refs/heads/master' }}

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/dependencies/DefaultArtifactPinnerTest.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/dependencies/DefaultArtifactPinnerTest.kt
@@ -12,6 +12,7 @@ import com.grab.grazel.gradle.dependencies.model.WorkspaceDependencies
 import com.grab.grazel.gradle.variant.DEFAULT_VARIANT
 import com.grab.grazel.util.BUILD_BAZEL
 import com.grab.grazel.util.NoOpProgressLogger
+import com.grab.grazel.util.ROOT_PATH
 import com.grab.grazel.util.WORKSPACE
 import com.grab.grazel.util.addGrazelExtension
 import com.grab.grazel.util.assertNoThrow
@@ -26,6 +27,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
+import kotlin.io.path.copyTo
 import kotlin.test.assertTrue
 
 class DefaultArtifactPinnerTest {
@@ -50,6 +52,8 @@ class DefaultArtifactPinnerTest {
         rootProject.file(WORKSPACE).writeText("")
         rootProject.file(BUILD_BAZEL).writeText("")
         rootProject.file("maven_install.json").writeText("")
+        rootProject.file(".bazelrc").writeText("common --enable_bzlmod=false")
+        ROOT_PATH.resolve(".bazelversion").copyTo(rootProject.file(".bazelversion").toPath())
 
         artifactPinner = rootProject
             .createGrazelComponent()

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/util/Paths.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/util/Paths.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 Grabtaxi Holdings PTE LTD (GRAB)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grab.grazel.util
+
+import java.nio.file.Path
+import java.nio.file.Paths
+
+
+val ROOT_PATH: Path = Paths.get(System.getProperty("user.dir")).let {
+    when {
+        it.endsWith("grazel-gradle-plugin") -> it.parent
+        else -> it
+    }
+}


### PR DESCRIPTION
## Proposed Changes

- Previous setup was dependant on github system image which can cause issues when they change. Explicitly setup android and bazel version in bazel action/
- Lock bazel version is tests
- Add a composite action for gradle.
- Add a composite action for android
- Update action versions