### PR TITLE
Add back support for `jetifyExcludeList`

### DIFF
--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/extension/MavenInstallExtension.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/extension/MavenInstallExtension.kt
@@ -42,17 +42,21 @@ internal val MAVEN_INSTALL_REPOSITORY = HttpArchiveRule(
 )
 
 /**
- * Configuration for [rules_jvm_external](github.com/bazelbuild/rules_jvm_external)'s maven_install rule.
+ * Configuration for [rules_jvm_external](github.com/bazelbuild/rules_jvm_external)'s maven_install
+ * rule.
  *
  * @param repository `WORKSPACE` repository details for `rules_jvm_external`
  * @param resolveTimeout Maps to `maven_install.resolve_timeout`
  * @param excludeArtifactsDenyList By default, per
- *      [artifact exclude rules](https://github.com/bazelbuild/rules_jvm_external#detailed-dependency-information-specifications)
- *      are automatically generated from Gradle, `excludeArtifactsDenyList` can be used to prevent an artifact from getting
- *      automatically excluded. Specify in maven `groupId:artifact` format.
- * @param excludeArtifacts Global exclude artifacts, maps to `maven_install.excluded_artifacts`. Specify in maven `groupId:artifact` format
- * @param overrideTargetLabels Map of `groupId:artifact` and bazel labels that will be specified to `maven_install.override_targets` param.
- * @param jetifyIncludeList Maven artifacts in `groupId:artifact` format that should be added `maven_install.jetify_include_list`
+ *    [artifact exclude rules](https://github.com/bazelbuild/rules_jvm_external#detailed-dependency-information-specifications)
+ *    are automatically generated from Gradle, `excludeArtifactsDenyList` can be used to prevent an
+ *    artifact from getting automatically excluded. Specify in maven `groupId:artifact` format.
+ * @param excludeArtifacts Global exclude artifacts, maps to `maven_install.excluded_artifacts`.
+ *    Specify in maven `groupId:artifact` format
+ * @param overrideTargetLabels Map of `groupId:artifact` and bazel labels that will be specified to
+ *    `maven_install.override_targets` param.
+ * @param jetifyIncludeList Maven artifacts in `groupId:artifact` format that should be added
+ *    `maven_install.jetify_include_list`
  */
 data class MavenInstallExtension(
     private val objects: ObjectFactory,
@@ -63,6 +67,7 @@ data class MavenInstallExtension(
     var overrideTargetLabels: MapProperty<String, String> = objects.mapProperty(),
     var excludeArtifacts: ListProperty<String> = objects.listProperty(),
     var jetifyIncludeList: ListProperty<String> = objects.listProperty(),
+    var jetifyExcludeList: ListProperty<String> = objects.listProperty(),
     var versionConflictPolicy: String? = null,
     var includeCredentials: Boolean = true,
 ) {

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/dependencies/MavenInstallArtifactsCalculator.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/dependencies/MavenInstallArtifactsCalculator.kt
@@ -31,7 +31,7 @@ import com.grab.grazel.gradle.variant.DEFAULT_VARIANT
 import org.gradle.api.artifacts.repositories.PasswordCredentials
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.internal.artifacts.repositories.DefaultMavenArtifactRepository
-import java.util.*
+import java.util.TreeSet
 import javax.inject.Inject
 
 /**
@@ -52,9 +52,7 @@ constructor(
 
     private val includeCredentials get() = mavenInstallExtension.includeCredentials
 
-    /**
-     * Map of user configured overrides for artifact versions.
-     */
+    /** Map of user configured overrides for artifact versions. */
     private val overrideVersionsMap: Map< /*shortId*/ String, /*version*/ String> by lazy {
         grazelExtension
             .dependencies
@@ -100,6 +98,7 @@ constructor(
                     .mapNotNull { if (it.requiresJetifier) it.shortId else it.jetifierSource }
                     .toList()
                     + mavenInstallExtension.jetifyIncludeList.get()
+                    - mavenInstallExtension.jetifyExcludeList.get().toSet()
                     - DefaultJetifierExclusions
                 ).toSortedSet()
 

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/dependencies/MavenInstallArtifactsCalculatorTest.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/dependencies/MavenInstallArtifactsCalculatorTest.kt
@@ -1,39 +1,101 @@
 package com.grab.grazel.migrate.dependencies
 
+import com.grab.grazel.GrazelExtension
 import com.grab.grazel.buildProject
+import com.grab.grazel.gradle.dependencies.model.ResolvedDependency
+import com.grab.grazel.gradle.dependencies.model.WorkspaceDependencies
 import com.grab.grazel.gradle.variant.setupAndroidVariantProject
 import com.grab.grazel.gradle.variant.setupJvmVariantProject
 import com.grab.grazel.util.addGrazelExtension
 import com.grab.grazel.util.createGrazelComponent
 import com.grab.grazel.util.doEvaluate
 import org.gradle.api.Project
-import org.junit.Before
+import org.gradle.kotlin.dsl.repositories
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.test.assertNotNull
 
 class MavenInstallArtifactsCalculatorTest {
     private lateinit var rootProject: Project
     private lateinit var androidProject: Project
     private lateinit var jvmProject: Project
     private lateinit var mavenInstallArtifactsCalculator: MavenInstallArtifactsCalculator
-    private val projectsToMigrate by lazy { listOf(rootProject, androidProject, jvmProject) }
 
-    @Before
-    fun setUp() {
-        rootProject = buildProject("root").also {
-            it.addGrazelExtension()
-        }
-        androidProject = buildProject("android", rootProject).also {
-            setupAndroidVariantProject(it)
-        }
-        jvmProject = buildProject("java", rootProject).also {
-            setupJvmVariantProject(it)
-        }
-        projectsToMigrate.forEach { it.doEvaluate() }
+    private fun setup(configure: GrazelExtension.() -> Unit = {}) {
+        rootProject = buildProject("root")
+        rootProject.addGrazelExtension(configure)
+
+        androidProject = buildProject("android", rootProject)
+        setupAndroidVariantProject(androidProject)
+        androidProject.repositories { mavenCentral() }
+
+        jvmProject = buildProject("java", rootProject)
+        setupJvmVariantProject(jvmProject)
+
+        listOf(rootProject, androidProject, jvmProject).forEach { it.doEvaluate() }
+
         val grazelComponent = rootProject.createGrazelComponent()
         mavenInstallArtifactsCalculator = grazelComponent.mavenInstallArtifactsCalculator().get()
     }
 
     @Test
-    fun `test`() {
+    fun `test jetifyExcludeList should remove artifacts from jetifier list`() {
+        setup {
+            rules {
+                mavenInstall {
+                    jetifyExcludeList.set(
+                        listOf(
+                            "androidx.core:core",
+                            "com.google.android:material"
+                        )
+                    )
+                }
+            }
+        }
+
+        val repository = "MavenRepo"
+
+        val workspaceDependencies = WorkspaceDependencies(
+            result = mapOf(
+                "debug" to listOf(
+                    ResolvedDependency.fromId("androidx.core:core:1.0.0", repository)
+                        .copy(requiresJetifier = true),
+                    ResolvedDependency.fromId("androidx.appcompat:appcompat:1.0.0", repository)
+                        .copy(requiresJetifier = true),
+                    ResolvedDependency.fromId("com.google.android:material:1.0.0", repository)
+                        .copy(requiresJetifier = true),
+                    ResolvedDependency.fromId("junit:junit:4.12", repository)
+                )
+            )
+        )
+
+        val result = mavenInstallArtifactsCalculator.get(
+            layout = rootProject.layout,
+            workspaceDependencies = workspaceDependencies,
+            externalArtifacts = emptySet(),
+            externalRepositories = emptySet()
+        )
+
+        // Verify results
+        val debugRepo = result.find { it.name == "debug_maven" }
+        assertNotNull(debugRepo, "Debug repository should exist")
+
+        // Verify excluded artifacts are not included
+        val jetifiedArtifacts = debugRepo.jetifierConfig.artifacts
+        assertFalse(
+            "androidx.core:core should be excluded from jetifier list",
+            "androidx.core:core" in jetifiedArtifacts
+        )
+        assertFalse(
+            "com.google.android:material should be excluded from jetifier list",
+            "com.google.android:material" in jetifiedArtifacts
+        )
+
+        // Verify non-excluded artifact is included
+        assertTrue(
+            "androidx.appcompat:appcompat should be included in jetifier list",
+            "androidx.appcompat:appcompat" in jetifiedArtifacts
+        )
     }
 }


### PR DESCRIPTION
## Proposed Changes

- https://github.com/grab/grazel/pull/100 removed support for `jetifyExcludeList` in favor of automatically calculating it. However we find this is still useful to mimic `android.jetifier.ignorelist` functionality for artifacts that have trouble.