### PR TITLE
Implement support for calculating tests' `size` attribute

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import com.grab.grazel.bazel.TestSize
+
 /*
  * Copyright 2022 Grabtaxi Holdings PTE LTD (GRAB)
  *
@@ -148,6 +150,11 @@ grazel {
     }
     experiments {
         limitDependencyResolutionParallelism.set(true)
+    }
+    test {
+        testSizeProvider = { testData ->
+            TestSize.MEDIUM
+        }
     }
 }
 

--- a/flavors/sample-library-demo/BUILD.bazel
+++ b/flavors/sample-library-demo/BUILD.bazel
@@ -15,6 +15,7 @@ kotlin_library(
 
 kotlin_test(
     name = "sample-library-demo-test",
+    size = "medium",
     srcs = glob([
         "src/test/java/com/grab/grazel/flavor1/ModuleNameTest.kt",
     ]),

--- a/flavors/sample-library-full/BUILD.bazel
+++ b/flavors/sample-library-full/BUILD.bazel
@@ -15,6 +15,7 @@ kotlin_library(
 
 kotlin_test(
     name = "sample-library-full-test",
+    size = "medium",
     srcs = glob([
         "src/test/java/com/grab/grazel/flavor2/ModuleNameTest.kt",
     ]),

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/GrazelExtension.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/GrazelExtension.kt
@@ -21,13 +21,16 @@ import com.grab.grazel.extension.DependenciesExtension
 import com.grab.grazel.extension.ExperimentsExtension
 import com.grab.grazel.extension.HybridExtension
 import com.grab.grazel.extension.RulesExtension
+import com.grab.grazel.extension.TestExtension
 import groovy.lang.Closure
 import org.gradle.api.Project
 
 /**
- * The extension allows to configure various Grazel attributes like migration behavior and generated rules configuration.
+ * The extension allows to configure various Grazel attributes like migration behavior and generated
+ * rules configuration.
  *
  * For example
+ *
  * ```
  * grazel {
  *    android {
@@ -54,13 +57,15 @@ open class GrazelExtension(
 
     val rules = RulesExtension(rootProject.objects)
 
+    val test = TestExtension(rootProject.objects)
+
     val hybrid = HybridExtension(rootProject.objects)
 
     val experiments = ExperimentsExtension(rootProject.objects)
 
     /**
-     * Android specific configuration used to configure parameters for android_binary or other android related
-     * rules
+     * Android specific configuration used to configure parameters for android_binary or other
+     * android related rules
      *
      * ```
      * android {
@@ -78,8 +83,8 @@ open class GrazelExtension(
     }
 
     /**
-     * Android specific configuration used to configure parameters for android_binary or other android related
-     * rules
+     * Android specific configuration used to configure parameters for android_binary or other
+     * android related rules
      *
      * ```
      * android {
@@ -88,6 +93,7 @@ open class GrazelExtension(
      *   ...
      * }
      * ```
+     *
      * @param closure Closue for configuration with [AndroidExtension] instance as the delegate
      * @see AndroidExtension
      */
@@ -97,8 +103,8 @@ open class GrazelExtension(
     }
 
     /**
-     * Dependencies configuration used to control how dependencies should be handled during migration. For example,
-     *
+     * Dependencies configuration used to control how dependencies should be handled during
+     * migration. For example,
      * ```
      * dependencies {
      *   ignoreArtifacts = []
@@ -114,14 +120,15 @@ open class GrazelExtension(
     }
 
     /**
-     * Dependencies configuration used to control how dependencies should be handled during migration. For example,
-     *
+     * Dependencies configuration used to control how dependencies should be handled during
+     * migration. For example,
      * ```
      * dependencies {
      *   ignoreArtifacts = []
      *   ...
      * }
      * ```
+     *
      * @param closure Closure for configuration with [DependenciesExtension] instance as delegate
      * @see DependenciesExtension
      */
@@ -131,7 +138,8 @@ open class GrazelExtension(
     }
 
     /**
-     * Top level rules configuration block to configure various rules. For list of available rule configurations
+     * Top level rules configuration block to configure various rules. For list of available rule
+     * configurations
      *
      * ```
      * rules {
@@ -139,6 +147,7 @@ open class GrazelExtension(
      *   }
      * }
      * ```
+     *
      * @param block Configuration block with [RulesExtension] as the receiver
      * @see RulesExtension
      */
@@ -147,7 +156,8 @@ open class GrazelExtension(
     }
 
     /**
-     * Top level rules configuration block to configure various rules. For list of available rule configurations
+     * Top level rules configuration block to configure various rules. For list of available rule
+     * configurations
      *
      * ```
      * rules {
@@ -155,6 +165,7 @@ open class GrazelExtension(
      *   }
      * }
      * ```
+     *
      * @param closure Closure block for configuration with [RulesExtension] as the delegate
      * @see RulesExtension
      */
@@ -171,8 +182,9 @@ open class GrazelExtension(
      *
      * }
      * ```
-     * @see HybridExtension
+     *
      * @param block Configuration block with [HybridExtension] as the receiver
+     * @see HybridExtension
      */
     fun hybrid(block: HybridExtension.() -> Unit) {
         block(hybrid)
@@ -186,8 +198,9 @@ open class GrazelExtension(
      *
      * }
      * ```
-     * @see HybridExtension
+     *
      * @param closure Closure block with [HybridExtension] as the delegate
+     * @see HybridExtension
      */
     fun hybrid(closure: Closure<*>) {
         closure.delegate = hybrid
@@ -202,8 +215,9 @@ open class GrazelExtension(
      *
      * }
      * ```
-     * @see ExperimentsExtension
+     *
      * @param block Configuration block with [ExperimentsExtension] as the receiver
+     * @see ExperimentsExtension
      */
     fun experiments(block: ExperimentsExtension.() -> Unit) {
         block(experiments)
@@ -217,11 +231,45 @@ open class GrazelExtension(
      *
      * }
      * ```
-     * @see ExperimentsExtension
+     *
      * @param closure Closure block with [ExperimentsExtension] as the delegate
+     * @see ExperimentsExtension
      */
     fun experiments(closure: Closure<*>) {
         closure.delegate = experiments
+        closure.call()
+    }
+
+    /**
+     * Extension to configure test related configurations
+     *
+     * ```
+     * test {
+     *
+     * }
+     * ```
+     *
+     * @param block Configuration block with [TestExtension] as the receiver
+     * @see TestExtension
+     */
+    fun test(block: TestExtension.() -> Unit) {
+        block(test)
+    }
+
+    /**
+     * Extension to configure test related configurations
+     *
+     * ```
+     * test {
+     *
+     * }
+     * ```
+     *
+     * @param closure Closure block with [TestExtension] as the delegate
+     * @see TestExtension
+     */
+    fun test(closure: Closure<*>) {
+        closure.delegate = test
         closure.call()
     }
 }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/Bazel.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/Bazel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Grabtaxi Holdings PTE LTD (GRAB)
+ * Copyright 2025 Grabtaxi Holdings PTE LTD (GRAB)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,10 @@
  * limitations under the License.
  */
 
-package com.grab.grazel.android.sample
+package com.grab.grazel.bazel
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+// TODO(arun) Move all bazel type definitions here
 
-class FoolTest {
-
-    @Test
-    fun method1() {
-        println("Class 1 test 1")
-        assertEquals(4, 2 + 2)
-    }
-
-    @Test
-    fun method2() {
-        println("Class 1 test 2")
-        assertEquals(6, 4 + 2)
-    }
+enum class TestSize {
+    SMALL, MEDIUM, LARGE, ENORMOUS
 }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/AndroidRules.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/AndroidRules.kt
@@ -16,6 +16,7 @@
 
 package com.grab.grazel.bazel.rules
 
+import com.grab.grazel.bazel.TestSize
 import com.grab.grazel.bazel.starlark.Assignee
 import com.grab.grazel.bazel.starlark.BazelDependency
 import com.grab.grazel.bazel.starlark.StatementsBuilder
@@ -289,6 +290,7 @@ fun StatementsBuilder.androidUnitTest(
     enableCompose: Boolean = false,
     tags: List<String> = emptyList(),
     resourcesGlob: List<String> = emptyList(),
+    testSize: TestSize = TestSize.MEDIUM,
 ) {
     load("@$GRAB_BAZEL_COMMON//rules:defs.bzl", "android_unit_test")
 
@@ -304,6 +306,7 @@ fun StatementsBuilder.androidUnitTest(
         srcsGlob.notEmpty {
             "srcs" `=` glob(srcsGlob.map(String::quote))
         }
+        "size" `=` testSize.name.lowercase().quote
         "visibility" `=` array(visibility.rule.quote)
         associates.notEmpty {
             "associates" `=` array(associates.map(BazelDependency::toString).map(String::quote))

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/KotlinRules.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/KotlinRules.kt
@@ -16,10 +16,10 @@
 
 package com.grab.grazel.bazel.rules
 
+import com.grab.grazel.bazel.TestSize
 import com.grab.grazel.bazel.rules.Visibility.Public
 import com.grab.grazel.bazel.starlark.Assignee
 import com.grab.grazel.bazel.starlark.BazelDependency
-import com.grab.grazel.migrate.android.LintConfigData
 import com.grab.grazel.bazel.starlark.StatementsBuilder
 import com.grab.grazel.bazel.starlark.add
 import com.grab.grazel.bazel.starlark.array
@@ -31,10 +31,9 @@ import com.grab.grazel.bazel.starlark.toObject
 import com.grab.grazel.extension.JavaCOptions
 import com.grab.grazel.extension.KotlinCOptions
 import com.grab.grazel.extension.KotlinToolChain
+import com.grab.grazel.migrate.android.LintConfigData
 
-/**
- * `WORKSPACE` rule that registers the given [repositoryRule].
- */
+/** `WORKSPACE` rule that registers the given [repositoryRule]. */
 fun StatementsBuilder.kotlinRepository(repositoryRule: BazelRepositoryRule) {
     add(repositoryRule)
     if (repositoryRule is GitRepositoryRule) {
@@ -76,8 +75,8 @@ fun StatementsBuilder.kotlinCompiler(
 }
 
 /**
- * `WORKSPACE` rule to generate Kotlin toolchain rule. If `toolchain.enabled` is set to `false`, will use the default Kotlin
- * otherwise will use the custom toolchain parameters.
+ * `WORKSPACE` rule to generate Kotlin toolchain rule. If `toolchain.enabled` is set to `false`,
+ * will use the default Kotlin otherwise will use the custom toolchain parameters.
  */
 fun StatementsBuilder.registerKotlinToolchain(toolchain: KotlinToolChain) {
     if (toolchain.enabled) {
@@ -204,7 +203,8 @@ fun StatementsBuilder.kotlinTest(
     associates: List<BazelDependency> = emptyList(),
     deps: List<BazelDependency> = emptyList(),
     plugins: List<BazelDependency> = emptyList(),
-    tags: List<String> = emptyList()
+    tags: List<String> = emptyList(),
+    testSize: TestSize = TestSize.MEDIUM,
 ) {
     load("@$GRAB_BAZEL_COMMON//rules:defs.bzl", "kotlin_test")
 
@@ -216,6 +216,7 @@ fun StatementsBuilder.kotlinTest(
         srcsGlob.notEmpty {
             "srcs" `=` glob(srcsGlob.map(String::quote))
         }
+        "size" `=` testSize.name.lowercase().quote
         additionalSrcSets.notEmpty {
             "additional_src_sets" `=` additionalSrcSets.map(String::quote)
         }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/extension/TestExtension.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/extension/TestExtension.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Grabtaxi Holdings PTE LTD (GRAB)
+ * Copyright 2025 Grabtaxi Holdings PTE LTD (GRAB)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,46 +16,33 @@
 
 package com.grab.grazel.extension
 
-import com.grab.grazel.bazel.rules.BazelRepositoryRule
-import com.grab.grazel.bazel.rules.GitRepositoryRule
-import com.grab.grazel.bazel.rules.HttpArchiveRule
-import groovy.lang.Closure
+import com.grab.grazel.bazel.TestSize
+import org.gradle.api.model.ObjectFactory
 
-
-private const val DEFAULT_ROBOLECTRIC_VERSION = "4.4"
-private const val ROBOLECTRIC = "robolectric"
-private const val DEFAULT_ROBOLECTRIC_STRIP_PREFIX = "robolectric-bazel-%s"
-private const val DEFAULT_ROBOLECTRIC_URL =
-    "https://github.com/robolectric/robolectric-bazel/archive/%s.tar.gz"
-
-private val DEFAULT_ROBOLECTRIC_ARCHIVE = HttpArchiveRule(
-    name = ROBOLECTRIC,
-    stripPrefix = String.format(DEFAULT_ROBOLECTRIC_STRIP_PREFIX, DEFAULT_ROBOLECTRIC_VERSION),
-    url = String.format(DEFAULT_ROBOLECTRIC_URL, DEFAULT_ROBOLECTRIC_VERSION)
+/**
+ * Data class containing test metrics used to determine test size.
+ *
+ * @property targetName The name of the test target
+ * @property testsCount The total number of test cases/methods (@Test) in a
+ *    test target
+ * @property testFileCount The total number of test files/classes in a test
+ *    target
+ */
+data class TestData(
+    val targetName: String,
+    val testsCount: Int,
+    val testFileCount: Int
 )
 
-data class RobolectricExtension(
-    var repository: BazelRepositoryRule = DEFAULT_ROBOLECTRIC_ARCHIVE,
-    var version: String = DEFAULT_ROBOLECTRIC_VERSION
-) {
-
-    fun gitRepository(closure: Closure<*>) {
-        repository = GitRepositoryRule(name = ROBOLECTRIC)
-        closure.delegate = repository
-        closure.call()
-    }
-
-    fun gitRepository(builder: GitRepositoryRule.() -> Unit) {
-        repository = GitRepositoryRule(name = ROBOLECTRIC).apply(builder)
-    }
-
-    fun httpArchiveRepository(closure: Closure<*>) {
-        repository = DEFAULT_ROBOLECTRIC_ARCHIVE
-        closure.delegate = repository
-        closure.call()
-    }
-
-    fun httpArchiveRepository(builder: HttpArchiveRule.() -> Unit) {
-        repository = DEFAULT_ROBOLECTRIC_ARCHIVE.apply(builder)
-    }
-}
+/**
+ * Extension to configure test related settings.
+ *
+ * @property testSizeProvider Function that takes [TestData] and returns a
+ *    [TestSize]. Used to calculate the `size` attribute for test targets
+ *    in Bazel based on test metrics like number of test cases. Defaults to
+ *    MEDIUM size for all tests.
+ */
+class TestExtension(
+    val objects: ObjectFactory,
+    var testSizeProvider: (TestData) -> TestSize = { TestSize.MEDIUM },
+)

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidUnitTestData.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidUnitTestData.kt
@@ -16,6 +16,7 @@
 
 package com.grab.grazel.migrate.android
 
+import com.grab.grazel.bazel.TestSize
 import com.grab.grazel.bazel.starlark.BazelDependency
 
 data class AndroidUnitTestData(
@@ -28,6 +29,7 @@ data class AndroidUnitTestData(
     val associates: List<BazelDependency>,
     val resources: List<String>,
     val compose: Boolean,
+    val testSize: TestSize = TestSize.MEDIUM
 )
 
 internal fun AndroidUnitTestData.toUnitTestTarget() = AndroidUnitTestTarget(
@@ -39,5 +41,6 @@ internal fun AndroidUnitTestData.toUnitTestTarget() = AndroidUnitTestTarget(
     customPackage = customPackage,
     resources = resources,
     tags = tags,
-    compose = compose
+    compose = compose,
+    testSize = testSize,
 )

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidUnitTestTarget.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/android/AndroidUnitTestTarget.kt
@@ -16,6 +16,7 @@
 
 package com.grab.grazel.migrate.android
 
+import com.grab.grazel.bazel.TestSize
 import com.grab.grazel.bazel.rules.Visibility
 import com.grab.grazel.bazel.rules.androidUnitTest
 import com.grab.grazel.bazel.starlark.BazelDependency
@@ -34,6 +35,7 @@ internal data class AndroidUnitTestTarget(
     val resources: List<String> = emptyList(),
     val additionalSrcSets: List<String> = emptyList(),
     val compose: Boolean,
+    val testSize: TestSize,
 ) : BazelBuildTarget {
     override fun statements(builder: StatementsBuilder) = builder {
         if (srcs.isNotEmpty()) {
@@ -48,6 +50,7 @@ internal data class AndroidUnitTestTarget(
                 resourcesGlob = resources,
                 enableCompose = compose,
                 additionalSrcSets = additionalSrcSets,
+                testSize = testSize,
             )
         }
     }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/common/TestAssociates.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/common/TestAssociates.kt
@@ -24,14 +24,15 @@ import com.grab.grazel.gradle.isKotlin
 import org.gradle.api.Project
 
 /**
- * For given `project`, calculate the associate target name. This is needed since we have macros like `kt_android_library`
- * or `kt_db_android_library` which are macros and hide the actual kotlin targets differently. This method chooses the correct
- * associate target - which is the Kotlin target based on project type.
+ * For given `project`, calculate the associate target name. This is needed since we have macros
+ * like `kt_android_library` or `kt_db_android_library` which are macros and hide the actual kotlin
+ * targets differently. This method chooses the correct associate target - which is the Kotlin
+ * target based on project type.
  *
  * @param project The project for which associate needs to be calculated
  * @return The associate that was calculated, null otherwise
  */
-internal fun calculateTestAssociate(project: Project, suffix: String = ""): BazelDependency? {
+internal fun calculateTestAssociates(project: Project, suffix: String = ""): BazelDependency? {
     return when {
         project.isKotlin && project.isAndroid -> return StringDependency(
             """${ProjectDependency(project, suffix)}_kt"""

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/common/TestSizeCalculator.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/common/TestSizeCalculator.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 Grabtaxi Holdings PTE LTD (GRAB)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grab.grazel.migrate.common
+
+import com.grab.grazel.GrazelExtension
+import com.grab.grazel.bazel.TestSize
+import com.grab.grazel.extension.TestData
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flatMapMerge
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.fold
+import kotlinx.coroutines.runBlocking
+import java.io.File
+import javax.inject.Inject
+
+internal class TestSizeCalculator
+@Inject
+constructor(
+    private val grazelExtension: GrazelExtension,
+) {
+    private fun File.isTestFile() = name.endsWith("Test.kt")
+        || name.endsWith("Tests.kt")
+
+    private fun File.hasJUnitImport() = useLines { lines ->
+        lines.any { it.trim().matches(Regex("""import\s+org\.junit\.Test""")) }
+    }
+
+    private fun File.countTestAnnotations() = useLines { lines ->
+        lines.count { it.trim().startsWith("@Test") }
+    }
+
+    fun calculate(name: String, sources: Set<File>): TestSize = runBlocking {
+        val result = sources.asFlow()
+            .filter(File::exists)
+            .flatMapMerge(concurrency = 4) { file ->
+                file.walkBottomUp()
+                    .filter { it.isFile }
+                    .filter { it.isTestFile() }
+                    .filter { it.hasJUnitImport() }
+                    .asFlow()
+            }.flatMapMerge(concurrency = 4) { file ->
+                flow {
+                    emit(TestFileData(file, file.countTestAnnotations()))
+                }
+            }.fold(initial = TestFileStats(0, 0)) { acc, fileData ->
+                TestFileStats(
+                    testCount = acc.testCount + fileData.testCount,
+                    fileCount = acc.fileCount + 1
+                )
+            }
+        val finalTestData = TestData(
+            targetName = name,
+            testsCount = result.testCount,
+            testFileCount = result.fileCount
+        )
+        if (finalTestData.isValid) {
+            grazelExtension.test.testSizeProvider(finalTestData)
+        } else {
+            TestSize.MEDIUM
+        }
+    }
+
+    private data class TestFileData(val file: File, val testCount: Int)
+    private data class TestFileStats(val testCount: Int, val fileCount: Int)
+
+    companion object {
+        internal val TestData.isValid: Boolean
+            get() = testsCount > 0 && testFileCount > 0
+    }
+}

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/UnitTestData.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/UnitTestData.kt
@@ -16,6 +16,7 @@
 
 package com.grab.grazel.migrate.kotlin
 
+import com.grab.grazel.bazel.TestSize
 import com.grab.grazel.bazel.starlark.BazelDependency
 import com.grab.grazel.migrate.BazelBuildTarget
 import com.grab.grazel.migrate.android.AndroidUnitTestTarget
@@ -27,6 +28,7 @@ data class UnitTestData(
     val deps: List<BazelDependency>,
     val tags: List<String>,
     val associates: List<BazelDependency>,
+    val testSize: TestSize = TestSize.MEDIUM,
     val hasAndroidJarDep: Boolean = false,
 )
 
@@ -35,12 +37,13 @@ internal fun UnitTestData.toUnitTestTarget(): BazelBuildTarget =
         AndroidUnitTestTarget(
             name = name,
             srcs = srcs,
-            additionalSrcSets = additionalSrcSets,
             deps = deps,
+            tags = tags,
             associates = associates,
             customPackage = "",
-            tags = tags,
+            additionalSrcSets = additionalSrcSets,
             compose = false,
+            testSize = testSize,
         )
     } else {
         UnitTestTarget(
@@ -49,6 +52,7 @@ internal fun UnitTestData.toUnitTestTarget(): BazelBuildTarget =
             additionalSrcSets = additionalSrcSets,
             deps = deps,
             associates = associates,
+            testSize = testSize,
             tags = tags,
         )
     }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/UnitTestTarget.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/UnitTestTarget.kt
@@ -16,6 +16,7 @@
 
 package com.grab.grazel.migrate.kotlin
 
+import com.grab.grazel.bazel.TestSize
 import com.grab.grazel.bazel.rules.Visibility
 import com.grab.grazel.bazel.rules.kotlinTest
 import com.grab.grazel.bazel.starlark.BazelDependency
@@ -31,6 +32,7 @@ internal data class UnitTestTarget(
     override val sortKey: String = "1$name",
     val associates: List<BazelDependency> = emptyList(),
     val additionalSrcSets: List<String> = emptyList(),
+    val testSize: TestSize = TestSize.MEDIUM,
 ) : BazelBuildTarget {
     override fun statements(builder: StatementsBuilder) = builder {
         if (srcs.isNotEmpty()) {
@@ -39,6 +41,7 @@ internal data class UnitTestTarget(
                 srcsGlob = srcs,
                 additionalSrcSets = additionalSrcSets,
                 deps = deps,
+                testSize = testSize,
                 visibility = visibility,
                 associates = associates,
                 tags = tags

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/android/DefaultAndroidUnitTestDataExtractorTest.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/android/DefaultAndroidUnitTestDataExtractorTest.kt
@@ -34,6 +34,7 @@ import com.grab.grazel.gradle.variant.DefaultAndroidVariantDataSource
 import com.grab.grazel.gradle.variant.DefaultAndroidVariantsExtractor
 import com.grab.grazel.gradle.variant.DefaultVariantBuilder
 import com.grab.grazel.gradle.variant.MatchedVariant
+import com.grab.grazel.migrate.common.TestSizeCalculator
 import com.grab.grazel.util.doEvaluate
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
@@ -112,13 +113,15 @@ class DefaultAndroidUnitTestDataExtractorTest : GrazelPluginTest() {
         val dependencyGraphs = FakeDependencyGraphs()
         val androidManifestParser: AndroidManifestParser = DefaultAndroidManifestParser()
 
+        val extension = GrazelExtension(rootProject)
         defaultAndroidUnitTestDataExtractor = DefaultAndroidUnitTestDataExtractor(
             dependenciesDataSource = dependenciesDataSource,
             dependencyGraphsProvider = { dependencyGraphs },
             androidManifestParser = androidManifestParser,
             variantDataSource = variantDataSource,
-            grazelExtension = GrazelExtension(rootProject),
-            gradleDependencyToBazelDependency = gradleDependencyToBazelDependency
+            grazelExtension = extension,
+            gradleDependencyToBazelDependency = gradleDependencyToBazelDependency,
+            testSizeCalculator = TestSizeCalculator(extension)
         )
     }
 

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/common/TestSizeCalculatorTest.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/common/TestSizeCalculatorTest.kt
@@ -1,0 +1,167 @@
+package com.grab.grazel.migrate.common
+
+import com.grab.grazel.GrazelExtension
+import com.grab.grazel.bazel.TestSize
+import com.grab.grazel.buildProject
+import com.grab.grazel.migrate.common.TestSizeCalculator.Companion.isValid
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import kotlin.test.assertTrue
+
+class TestSizeCalculatorTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private lateinit var grazelExtension: GrazelExtension
+    private lateinit var testSizeCalculator: TestSizeCalculator
+
+    @Before
+    fun setup() {
+        val rootProject = buildProject("dummy")
+        grazelExtension = GrazelExtension(rootProject).apply {
+            test {
+                testSizeProvider = { TestSize.SMALL }
+            }
+        }
+        testSizeCalculator = TestSizeCalculator(grazelExtension)
+    }
+
+    private fun createTestFile(path: String, content: String): File {
+        return temporaryFolder.newFile(path).apply {
+            writeText(content.trimIndent())
+        }
+    }
+
+    @Test
+    fun `test calculate returns MEDIUM when no valid test files found`() {
+        val nonTestFile = createTestFile(
+            path = "Example.kt",
+            content = """
+                package com.example
+                class Example
+            """
+        )
+
+        val result = testSizeCalculator.calculate("example", setOf(nonTestFile))
+        assertEquals(TestSize.MEDIUM, result)
+    }
+
+    @Test
+    fun `test calculate returns correct size for single test file`() {
+        val testFile = createTestFile(
+            path = "ExampleTest.kt",
+            content = """
+                package com.example
+                import org.junit.Test
+                
+                class ExampleTest {
+                    @Test
+                    fun test1() {}
+                    
+                    @Test
+                    fun test2() {}
+                }
+            """
+        )
+
+        grazelExtension.test.testSizeProvider = { testData ->
+            assertTrue(testData.isValid)
+            assertEquals("example", testData.targetName)
+            assertEquals(2, testData.testsCount)
+            assertEquals(1, testData.testFileCount)
+            TestSize.LARGE
+        }
+
+        val result = testSizeCalculator.calculate("example", setOf(testFile))
+        assertEquals(TestSize.LARGE, result)
+    }
+
+    @Test
+    fun `test calculate handles multiple test files`() {
+        val testFile1 = createTestFile(
+            path = "FirstTest.kt",
+            content = """
+                package com.example
+                import org.junit.Test
+                
+                class FirstTest {
+                    @Test
+                    fun test1() {}
+                }
+            """
+        )
+
+        val testFile2 = createTestFile(
+            path = "SecondTest.kt",
+            content = """
+                package com.example
+                import org.junit.Test
+                
+                class SecondTest {
+                    @Test
+                    fun test2() {}
+                    
+                    @Test
+                    fun test3() {}
+                }
+            """
+        )
+
+        grazelExtension.test.testSizeProvider = { testData ->
+            assertTrue(testData.isValid)
+            assertEquals("example", testData.targetName)
+            assertEquals(3, testData.testsCount)
+            assertEquals(2, testData.testFileCount)
+            TestSize.ENORMOUS
+        }
+
+        val result = testSizeCalculator.calculate("example", setOf(testFile1, testFile2))
+        assertEquals(TestSize.ENORMOUS, result)
+    }
+
+    @Test
+    fun `test calculate ignores non-test files and files without JUnit imports`() {
+        val regularFile = createTestFile(
+            path = "Regular.kt",
+            content = "class Regular"
+        )
+
+        val nonJunitTestFile = createTestFile(
+            path = "NonJunitTest.kt",
+            content = """
+                class NonJunitTest {
+                    @Test // Not a JUnit test
+                    fun test() {}
+                }
+            """
+        )
+
+        val validTestFile = createTestFile(
+            path = "ValidTest.kt",
+            content = """
+                import org.junit.Test
+                
+                class ValidTest {
+                    @Test
+                    fun test() {}
+                }
+            """
+        )
+
+        grazelExtension.test.testSizeProvider = { testData ->
+            assertEquals(1, testData.testsCount)
+            assertEquals(1, testData.testFileCount)
+            TestSize.SMALL
+        }
+
+        val result = testSizeCalculator.calculate(
+            "example",
+            setOf(regularFile, nonJunitTestFile, validTestFile)
+        )
+        assertEquals(TestSize.SMALL, result)
+    }
+} 

--- a/sample-kotlin-library/BUILD.bazel
+++ b/sample-kotlin-library/BUILD.bazel
@@ -17,8 +17,9 @@ kotlin_library(
 
 kotlin_test(
     name = "sample-kotlin-library-test",
+    size = "medium",
     srcs = glob([
-        "src/test/java/com/grab/grazel/sample/TestClass1.kt",
+        "src/test/java/com/grab/grazel/sample/SampleTest.kt",
     ]),
     associates = [
         "//sample-kotlin-library:sample-kotlin-library",

--- a/sample-kotlin-library/src/test/java/com/grab/grazel/sample/SampleTest.kt
+++ b/sample-kotlin-library/src/test/java/com/grab/grazel/sample/SampleTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Grabtaxi Holdings PTE LTD (GRAB)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grab.grazel.sample
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FoolTest {
+
+    @Test
+    fun method1() {
+        println("Class 1 test 1")
+        assertEquals(4, 2 + 2)
+    }
+
+    @Test
+    fun method2() {
+        println("Class 1 test 2")
+        assertEquals(6, 4 + 2)
+    }
+}


### PR DESCRIPTION
## Proposed Changes

1. Add support for calculating test size attribute based on input from user. 
2. For calculating the size, a `TestData` is passed with total `@Test` count as well as total file count.
3. Added tests.