### PR TITLE
Optimize variant dependency resolution by skipping variants without unique deps

### DIFF
--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/gradle/variant/Variant.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/gradle/variant/Variant.kt
@@ -91,6 +91,16 @@ fun BaseVariant.toVariantType(): VariantType = when (this) {
 
 val Variant<*>.isBase get() = name == DEFAULT_VARIANT
 
+/**
+ * Returns true if this variant only extends from default variants (default, test, androidTest).
+ * Such variants define the hierarchy structure and must always resolve dependencies
+ * to create proper maven buckets for downstream composite variants.
+ */
+val Variant<*>.extendsOnlyFromDefaultVariants: Boolean
+    get() = extendsFrom.isEmpty() || extendsFrom.all {
+        it == DEFAULT_VARIANT || it == TEST_VARIANT || it == ANDROID_TEST_VARIANT
+    }
+
 val Variant<*>.id get() = name + variantType.toString()
 
 val VariantType.isAndroidTest get() = this == AndroidTest


### PR DESCRIPTION
Skip expensive Gradle dependency resolution for variants that don't have unique dependencies declared directly on their configuration buckets.

Changes:
- Add `extendsOnlyFromDefaultVariants` extension to identify hierarchy-defining variants (default, debug, release, flavors, test, androidTest) that must always resolve to create proper maven buckets
- Add `hasUniqueDependencies()` to check if a variant has direct dependencies on its own Implementation/Api/CompileOnly configs without triggering resolution
- Register no-op tasks for variants without unique deps, producing empty JSON
- Variants with flavor+buildType specific deps are correctly detected and resolved

This reduces configuration time by skipping resolution for composite variants that only inherit dependencies from parent variants.

## Proposed Changes

## Testing

<!--- Please describe how you tested your changes. -->

## Issues Fixed