### PR TITLE
Add ksp compiler support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,14 +12,26 @@ KOTLIN_VERSION = "1.8.10"
 
 KOTLINC_RELEASE_SHA = "4c3fa7bc1bb9ef3058a2319d8bcc3b7196079f88e92fdcd8d304a46f4b6b5787"
 
-load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories", "kotlinc_version")
+KSP_VERSION = "1.8.10-1.0.9"
+
+KSP_COMPILER_RELEASE_SHA = "2f60c27956e4033c4c94355624e3fe88f255df42d8b67af44c1f2cdcbd513a13"
+
+load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories", "kotlinc_version", "ksp_version")
 
 KOTLINC_RELEASE = kotlinc_version(
     release = KOTLIN_VERSION,
     sha256 = KOTLINC_RELEASE_SHA,
 )
 
-kotlin_repositories(compiler_release = KOTLINC_RELEASE)
+KSP_COMPILER_RELEASE = ksp_version(
+    release = KSP_VERSION,
+    sha256 = KSP_COMPILER_RELEASE_SHA,
+)
+
+kotlin_repositories(
+    compiler_release = KOTLINC_RELEASE,
+    ksp_compiler_release = KSP_COMPILER_RELEASE,
+)
 
 register_toolchains("//:kotlin_toolchain")
 

--- a/build.gradle
+++ b/build.gradle
@@ -129,6 +129,10 @@ grazel {
                 tag = "1.8.10"
                 sha = "4c3fa7bc1bb9ef3058a2319d8bcc3b7196079f88e92fdcd8d304a46f4b6b5787"
             }
+            kspCompiler {
+                tag = "1.8.10-1.0.9"
+                sha = "2f60c27956e4033c4c94355624e3fe88f255df42d8b67af44c1f2cdcbd513a13"
+            }
             toolchain {
                 enabled = true
                 apiVersion = "1.7"

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/extension/KotlinExtension.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/extension/KotlinExtension.kt
@@ -71,6 +71,18 @@ data class KotlinCompiler(
 )
 
 /**
+ * Configuration for KSP (Kotlin Symbol Processing) compiler.
+ * When configured, KSP compiler release will be added to kotlin_repositories in WORKSPACE.
+ *
+ * @param tag KSP version tag (e.g., "1.8.10-1.0.9")
+ * @param sha SHA256 hash of the KSP compiler release
+ */
+data class KspCompiler(
+    var tag: String? = null,
+    var sha: String? = null
+)
+
+/**
  * Configuration for Kotlin compiler and toolchains. Options configured will be used in root `BUILD.bazel`, `WORKSPACE`
  * respectively.
  *
@@ -95,6 +107,7 @@ data class KotlinCompiler(
  */
 data class KotlinExtension(
     val compiler: KotlinCompiler = KotlinCompiler(),
+    val kspCompiler: KspCompiler = KspCompiler(),
     val kotlinCOptions: KotlinCOptions = KotlinCOptions(),
     val javaCOptions: JavaCOptions = JavaCOptions(),
     val toolchain: KotlinToolChain = KotlinToolChain(),
@@ -134,6 +147,15 @@ data class KotlinExtension(
 
     fun compiler(closure: Closure<*>) {
         closure.delegate = compiler
+        closure.call()
+    }
+
+    fun kspCompiler(block: KspCompiler.() -> Unit) {
+        block(kspCompiler)
+    }
+
+    fun kspCompiler(closure: Closure<*>) {
+        closure.delegate = kspCompiler
         closure.call()
     }
 

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/internal/WorkspaceBuilder.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/internal/WorkspaceBuilder.kt
@@ -196,12 +196,18 @@ internal class WorkspaceBuilder(
      * Add Kotlin specific statements to WORKSPACE namely
      * * Kotlin repository
      * * Kotlin compiler
+     * * KSP compiler (if configured)
      * * Registering toolchains
      */
     private fun StatementsBuilder.kotlinRules() {
         val kotlin = grazelExtension.rules.kotlin
         kotlinRepository(repositoryRule = kotlin.repository)
-        kotlinCompiler(kotlin.compiler.tag, kotlin.compiler.sha)
+        kotlinCompiler(
+            kotlinCompilerVersion = kotlin.compiler.tag,
+            kotlinCompilerReleaseSha = kotlin.compiler.sha,
+            kspCompilerVersion = kotlin.kspCompiler.tag,
+            kspCompilerReleaseSha = kotlin.kspCompiler.sha
+        )
         registerKotlinToolchain(toolchain = kotlin.toolchain)
     }
 }


### PR DESCRIPTION
## Proposed Changes
  ### Summary

  - Add optional KSP (Kotlin Symbol Processing) compiler configuration support
  - When kspCompiler is configured, generate ksp_version and related entries in WORKSPACE
  - Backwards compatible: existing configs without KSP continue to work unchanged

  ### Changes

  New DSL configuration:
```
  grazel {
      rules {
          kotlin {
              kspCompiler {
                  tag = "1.8.10-1.0.9"
                  sha = "2f60c27956e4033c4c94355624e3fe88f255df42d8b67af44c1f2cdcbd513a13"
              }
          }
      }
  }
```

  Generated WORKSPACE output (when configured):
  - Adds KSP_VERSION and KSP_COMPILER_RELEASE_SHA variables
  - Loads ksp_version from @io_bazel_rules_kotlin//kotlin:repositories.bzl
  - Passes ksp_compiler_release to kotlin_repositories()

  ## Testing

  - Added unit tests for KSP configured and not-configured scenarios
  - Run ./gradlew :grazel-gradle-plugin:test
  - Run ./gradlew migrateToBazel and verify WORKSPACE output



<!--- Please describe how you tested your changes. -->

## Issues Fixed