### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/actions/android/action.yml
+++ b/.github/actions/android/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Android SDK
-      uses: android-actions/setup-android@v3
+      uses: android-actions/setup-android@v3.2.2
       with:
         accept-android-sdk-licenses: 'true'
         log-accepted-android-sdk-licenses: 'false'

--- a/.github/actions/bazel/action.yml
+++ b/.github/actions/bazel/action.yml
@@ -1,5 +1,5 @@
 name: 'Run Bazel Command'
-description: 'Ensures bazelisk, mounts Bazel Cache from artifacts and runs Bazel command'
+description: 'Sets up Bazel with caching and runs Bazel command'
 inputs:
     bazel-command:
         description: 'The bazel command to run. Typically the arguments after bazelisk'
@@ -10,27 +10,22 @@ inputs:
 runs:
     using: "composite"
     steps:
-        -   name: Set Bazel version
-            shell: bash
-            run: echo "USE_BAZEL_VERSION=$(cat .bazelversion)" >> $GITHUB_ENV
+        - name: Setup Bazel
+          uses: bazel-contrib/setup-bazel@0.16.0
+          with:
+              bazelisk-cache: true
+              disk-cache: ${{ inputs.cache-key }}
+              repository-cache: true
 
-        -   name: Setup Bazelisk
-            uses: bazelbuild/setup-bazelisk@v3
-        -   name: Install JDK 17
-            uses: actions/setup-java@v4
-            with:
-                distribution: "zulu"
-                java-version: "17"
+        - name: Install JDK 17
+          uses: actions/setup-java@v5
+          with:
+              distribution: "zulu"
+              java-version: "17"
 
-        -   name: Setup Android SDK
-            uses: ./.github/actions/android
+        - name: Setup Android SDK
+          uses: ./.github/actions/android
 
-        -   name: Mount bazel cache
-            uses: actions/cache@v4
-            with:
-                path: "bazel-cache"
-                key: bazel-${{ inputs.cache-key }}
-
-        -   name: Run bazel command
-            shell: bash
-            run: bazelisk ${{ inputs.bazel-command }} --config=ci
+        - name: Run bazel command
+          shell: bash
+          run: bazelisk ${{ inputs.bazel-command }} --config=ci

--- a/.github/actions/gradle/action.yml
+++ b/.github/actions/gradle/action.yml
@@ -2,7 +2,7 @@ name: 'Run Gradle with Cache'
 description: 'Configures Gradle environment with JDK, Android SDK, and cache setup'
 inputs:
   job-id:
-    description: 'Unique identifier for the cache'
+    description: 'Unique identifier for the cache (kept for compatibility, not used)'
     required: true
   arguments:
     description: 'Gradle command arguments to execute'
@@ -17,7 +17,7 @@ runs:
   using: "composite"
   steps:
     - name: Install JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: "zulu"
         java-version: "17"
@@ -25,13 +25,13 @@ runs:
     - name: Setup Android SDK
       uses: ./.github/actions/android
 
-    - name: Run Gradle with Cache
-      uses: burrunan/gradle-cache-action@v1.12
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v5
       with:
-        debug: false
-        job-id: ${{ inputs.job-id }}
+        cache-read-only: ${{ inputs.read-only }}
         build-root-directory: ${{ inputs.build-root-directory }}
-        read-only: ${{ inputs.read-only }}
-        gradle-dependencies-cache-key: |
-          gradle/libs.versions.toml
-        arguments: ${{ inputs.arguments }} 
+
+    - name: Run Gradle
+      shell: bash
+      working-directory: ${{ inputs.build-root-directory }}
+      run: ./gradlew ${{ inputs.arguments }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout
-                uses: actions/checkout@v4
+                uses: actions/checkout@v6
             -   name: Install JDK 17
-                uses: actions/setup-java@v4
+                uses: actions/setup-java@v5
                 with:
                     distribution: "zulu"
                     java-version: "17"
@@ -33,7 +33,7 @@ jobs:
     bazel-build:
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
             -   name: Bazel build
                 uses: ./.github/actions/bazel
                 with:
@@ -42,7 +42,7 @@ jobs:
     bazel-test:
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
             -   name: Query targets
                 run: |
                     bazelisk query 'kind(kt_jvm_test, ...)' --output label > /tmp/targets
@@ -55,7 +55,7 @@ jobs:
     bazel-android-lint:
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
             -   name: Bazel Android Lint
                 uses: ./.github/actions/bazel
                 with:
@@ -65,7 +65,7 @@ jobs:
     grazel-build:
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
             -   name: Run Gradle build
                 uses: ./.github/actions/gradle
                 with:
@@ -76,7 +76,7 @@ jobs:
     grazel-test:
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
             -   name: Run Gradle tests
                 uses: ./.github/actions/gradle
                 with:
@@ -87,7 +87,7 @@ jobs:
     grazel-gradle-plugin-test:
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
             -   name: Test Gradle plugin
                 uses: ./.github/actions/gradle
                 with:
@@ -99,7 +99,7 @@ jobs:
     migrate-to-bazel-validation:
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
             -   name: Validate migration
                 uses: ./.github/actions/gradle
                 with:


### PR DESCRIPTION
- Replace burrunan/gradle-cache-action@v1.12 with gradle/actions/setup-gradle@v5 (official Gradle action with better caching)
- Replace archived bazelbuild/setup-bazelisk@v3 with bazel-contrib/setup-bazel@0.16.0 (actively maintained with built-in caching for bazelisk, disk, and repository)
- Update actions/checkout from v4 to v6
- Update actions/setup-java from v4 to v5
- Update android-actions/setup-android from v3 to v3.2.2