### PR TITLE
Rename resource_files to resources in KotlinRules

### DIFF
--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/KotlinRules.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/KotlinRules.kt
@@ -195,13 +195,13 @@ fun StatementsBuilder.ktLibrary(
             "deps" `=` array(deps.map(BazelDependency::toString).map(String::quote))
         }
         resourceFiles.notEmpty {
-            "resource_files" `=` resourceFiles.joinToString(
+            "resources" `=` resourceFiles.joinToString(
                 separator = " + ",
                 transform = Assignee::asString
             )
         }
         resources.notEmpty {
-            "resource_files" `=` glob(resources.quote)
+            "resources" `=` glob(resources.quote)
         }
         packageName?.let { "custom_package" `=` packageName.quote }
         manifest?.let { "manifest" `=` manifest.quote }


### PR DESCRIPTION
## Proposed Changes
- Renamed attribute from resource_files to resources (https://github.com/bazelbuild/rules_kotlin/blob/b4122754897017dfdbba842038f1c384fec78d5a/src/main/starlark/core/compile/rules.bzl#L40)

## Testing

<!--- Please describe how you tested your changes. -->

## Issues Fixed
- Bazel build was failing with an unresolved attribute error due to using resource_files, which is not a valid attribute in rules_kotlin.