### PR TITLE
Chore: Make Resolved Graph GC-able

### DIFF
--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/AnalyzeVariantCompressionTask.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/AnalyzeVariantCompressionTask.kt
@@ -34,6 +34,7 @@ import com.grab.grazel.gradle.variant.VariantType
 import com.grab.grazel.migrate.android.AndroidLibraryDataExtractor
 import com.grab.grazel.util.GradleProvider
 import com.grab.grazel.util.Json
+import com.grab.grazel.util.logHeap
 import dagger.Lazy
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
@@ -85,6 +86,7 @@ constructor(
 
     @TaskAction
     fun action() {
+        logger.logHeap("AnalyzeVariantCompression:start")
         dependencyResolutionService
             .get()
             .init(workspaceDependencies.get().asFile)

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/ComputeWorkspaceDependenciesTask.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/ComputeWorkspaceDependenciesTask.kt
@@ -24,6 +24,7 @@ import com.grab.grazel.gradle.dependencies.DependenciesDataSource
 import com.grab.grazel.gradle.variant.AndroidVariantDataSource
 import com.grab.grazel.gradle.variant.VariantBuilder
 import com.grab.grazel.util.GradleProvider
+import com.grab.grazel.util.logHeap
 import com.grab.grazel.util.writeJson
 import dagger.Lazy
 import kotlinx.coroutines.Dispatchers
@@ -37,6 +38,7 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
@@ -65,7 +67,9 @@ internal abstract class ComputeWorkspaceDependenciesTask : DefaultTask() {
 
     @TaskAction
     fun action() {
+        logger.logHeap("ComputeWorkspaceDeps:start")
         val result = ComputeWorkspaceDependencies().compute(compileDependenciesJsons.get())
+        logger.logHeap("ComputeWorkspaceDeps:computed")
         runBlocking {
             val populateCache = async(Dispatchers.Default) {
                 dependencyResolutionService.get().populateCache(result)
@@ -75,6 +79,7 @@ internal abstract class ComputeWorkspaceDependenciesTask : DefaultTask() {
             }
             awaitAll<Any>(populateCache, writeResult)
         }
+        logger.logHeap("ComputeWorkspaceDeps:done")
     }
 
     companion object {

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/GenerateBazelScriptsTask.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/GenerateBazelScriptsTask.kt
@@ -26,6 +26,7 @@ import com.grab.grazel.util.BUILD_BAZEL
 import com.grab.grazel.util.BUILD_BAZEL_IGNORE
 import com.grab.grazel.util.ansiGreen
 import com.grab.grazel.util.ansiYellow
+import com.grab.grazel.util.logHeap
 import dagger.Lazy
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
@@ -74,6 +75,7 @@ constructor(
 
     @TaskAction
     fun action() {
+        logger.logHeap("GeneratebazelScripts:${project.path}:start")
         val buildBazelFile = buildBazel.get().asFile
         val bazelIgnoreFile = project.file(BUILD_BAZEL_IGNORE)
 

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/GenerateRootBazelScriptsTask.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/GenerateRootBazelScriptsTask.kt
@@ -29,6 +29,7 @@ import com.grab.grazel.util.BUILD_BAZEL
 import com.grab.grazel.util.BUILD_BAZEL_IGNORE
 import com.grab.grazel.util.WORKSPACE
 import com.grab.grazel.util.ansiGreen
+import com.grab.grazel.util.logHeap
 import dagger.Lazy
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
@@ -76,6 +77,7 @@ constructor(
 
     @TaskAction
     fun action() {
+        logger.logHeap("GenerateRootBazelScripts:start")
         val rootProject = project.rootProject
         val projectsToMigrate = rootProject
             .subprojects
@@ -93,6 +95,7 @@ constructor(
             workspaceDependencies = workspaceDependencies
         ).build().writeToFile(workspaceFile.get().asFile)
         logger.quiet("Generated WORKSPACE".ansiGreen)
+        logger.logHeap("GenerateRootBazelScripts:workspace-done")
 
         val rootBuildBazelContents = rootBazelBuilderFactory.get()
             .create(

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/ResolveVariantDependenciesTask.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/ResolveVariantDependenciesTask.kt
@@ -31,6 +31,7 @@ import com.grab.grazel.gradle.variant.isBase
 import com.grab.grazel.gradle.variant.isTest
 import com.grab.grazel.util.dependsOn
 import com.grab.grazel.util.fromJson
+import com.grab.grazel.util.logHeap
 import com.grab.grazel.util.writeJson
 import dagger.Lazy
 import org.gradle.api.DefaultTask
@@ -52,6 +53,7 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -64,7 +66,6 @@ import java.util.TreeMap
 import java.util.TreeSet
 import kotlin.streams.asSequence
 
-@CacheableTask
 internal abstract class ResolveVariantDependenciesTask : DefaultTask() {
 
     @get:Input
@@ -73,7 +74,7 @@ internal abstract class ResolveVariantDependenciesTask : DefaultTask() {
     @get:Input
     abstract val base: Property<Boolean>
 
-    @get:Input
+    @get:Internal
     abstract val compileConfiguration: ListProperty<ResolvedComponentResult>
 
     @get:Input
@@ -82,13 +83,13 @@ internal abstract class ResolveVariantDependenciesTask : DefaultTask() {
     @get:Input
     abstract val compileExcludeRules: MapProperty</*shortId*/ String, Set<ExcludeRule>>
 
-    @get:Input
+    @get:Internal
     abstract val annotationProcessorConfiguration: ListProperty<ResolvedComponentResult>
 
-    @get:Input
+    @get:Internal
     abstract val kotlinCompilerPluginConfiguration: ListProperty<ResolvedComponentResult>
 
-    @get:Input
+    @get:Internal
     abstract val kspConfiguration: ListProperty<ResolvedComponentResult>
 
     @get:Input
@@ -156,6 +157,8 @@ internal abstract class ResolveVariantDependenciesTask : DefaultTask() {
 
     @TaskAction
     fun action() {
+        logger.logHeap("ResolveVariantDeps:${variantName.get()}:start")
+
         if (compileConfiguration.get().isEmpty()) {
             val emptyResult = ResolveDependenciesResult(
                 variantName = variantName.get(),
@@ -211,6 +214,22 @@ internal abstract class ResolveVariantDependenciesTask : DefaultTask() {
             }
         )
         writeJson(resolvedDependenciesResult, resolvedDependencies.get())
+
+        releaseResolvedGraphs()
+        logger.logHeap("ResolveVariantDeps:${variantName.get()}:done")
+    }
+
+    /**
+     * Clears the heavy [ResolvedComponentResult] properties after task execution.
+     * These hold the full transitive dependency graph in memory. In large project with thousand tasks,
+     * keeping them alive for the entire build causes OOM. The JSON output is already
+     * written to disk, so these are no longer needed.
+     */
+    private fun releaseResolvedGraphs() {
+        compileConfiguration.empty()
+        kspConfiguration.empty()
+        annotationProcessorConfiguration.empty()
+        kotlinCompilerPluginConfiguration.empty()
     }
 
     private data class KspDependencyInfo(

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/util/HeapStats.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/util/HeapStats.kt
@@ -1,0 +1,20 @@
+package com.grab.grazel.util
+
+import org.gradle.api.logging.Logger
+
+/**
+ * Logs current JVM heap usage. Only logs when `-Dgrazel.logHeap=true` is set.
+ */
+internal fun Logger.logHeap(phase: String) {
+    if (System.getProperty("grazel.logHeap") != "true") return
+    val runtime = Runtime.getRuntime()
+    val usedMb = (runtime.totalMemory() - runtime.freeMemory()) / (1024 * 1024)
+    val maxMb = runtime.maxMemory() / (1024 * 1024)
+    val pct = if (maxMb > 0) usedMb * 100 / maxMb else 0
+    lifecycle("Grazel: [$phase] heap: used ${formatMb(usedMb)} / max ${formatMb(maxMb)} ($pct%)")
+}
+
+private fun formatMb(mb: Long): String = when {
+    mb >= 1024 -> "%.1fG".format(mb / 1024.0)
+    else -> "${mb}M"
+}


### PR DESCRIPTION
## Proposed Changes
I observed the behavior of Grazel when running on large project with many variants. During Resolving Dependency phase, the heap is always slowly maxed and GC brings nothing to free the heap. Looking deeper, the whole graph of resolved component are retained because we mark them as `@Input` ([example](https://github.com/grab/grazel/blob/master/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/tasks/internal/ResolveVariantDependenciesTask.kt#L70)). This is beneficial for caching, but it keeps accumulating and block the other dependency resolution tasks, which defeats the benefit of caching altogether.

As we know the dependency resolution is written to the disk after the dependency is resolved, then we know actually the resolved graph can be GC-ed. Marking it as `@Internal` and remove the `@Cacheabletask` will make it GC-able, as it not held by gradle to be cached later. This way, when GC happen, we can freed more memory and make way for other dependency resolution tasks to run.

Also we add logHeap (can be activated by -Dgrazel.logHeap=true) to monitor the heap usage.



## Testing

<!--- Please describe how you tested your changes. -->

## Issues Fixed