### PR TITLE
Use resources attribute for JVM classpath resources in kt_jvm_library

### DIFF
--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/KotlinRules.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/bazel/rules/KotlinRules.kt
@@ -201,7 +201,7 @@ fun StatementsBuilder.ktLibrary(
             )
         }
         resources.notEmpty {
-            "resource_files" `=` glob(resources.quote)
+            "resources" `=` glob(resources.quote)
         }
         packageName?.let { "custom_package" `=` packageName.quote }
         manifest?.let { "manifest" `=` manifest.quote }

--- a/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/KotlinLibraryTarget.kt
+++ b/grazel-gradle-plugin/src/main/kotlin/com/grab/grazel/migrate/kotlin/KotlinLibraryTarget.kt
@@ -23,7 +23,6 @@ import com.grab.grazel.migrate.android.LintConfigData
 import com.grab.grazel.bazel.starlark.StatementsBuilder
 import com.grab.grazel.migrate.BazelBuildTarget
 import com.grab.grazel.migrate.android.ResValuesData
-import com.grab.grazel.migrate.android.buildResFiles
 
 internal data class KotlinLibraryTarget(
     override val name: String,
@@ -44,14 +43,13 @@ internal data class KotlinLibraryTarget(
 ) : BazelBuildTarget {
 
     override fun statements(builder: StatementsBuilder) = builder {
-        val resourceFiles = buildResFiles(res)
         ktLibrary(
             name = name,
             packageName = packageName,
             srcsGlob = srcs,
             visibility = visibility,
             deps = deps,
-            resourceFiles = resourceFiles,
+            resources = res,
             manifest = manifest,
             plugins = plugins,
             assetsGlob = assetsGlob,

--- a/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/kotlin/KotlinLibraryTargetTest.kt
+++ b/grazel-gradle-plugin/src/test/kotlin/com/grab/grazel/migrate/kotlin/KotlinLibraryTargetTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Grabtaxi Holdings PTE LTD (GRAB)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.grab.grazel.migrate.kotlin
+
+import com.grab.grazel.bazel.starlark.asString
+import com.grab.grazel.bazel.starlark.statements
+import com.grab.grazel.util.truth
+import org.junit.Test
+
+class KotlinLibraryTargetTest {
+
+    @Test
+    fun `emits JVM resources using kt_jvm_library resources attribute`() {
+        val serviceLoaderResource =
+            "src/main/resources/META-INF/services/com.android.tools.lint.client.api.IssueRegistry"
+
+        val target = KotlinLibraryTarget(
+            name = "custom-lint-rules",
+            srcs = listOf("src/main/java/com/grab/lint/rules/**/*.kt"),
+            deps = emptyList(),
+            res = listOf(serviceLoaderResource)
+        )
+
+        val generated = statements {
+            target.statements(this)
+        }.asString()
+
+        generated.truth {
+            contains("resources = glob([")
+            contains(serviceLoaderResource)
+            doesNotContain("resource_files")
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes
  Use resources attribute for JVM classpath resources in kt_jvm_library

  Switch KotlinLibraryTarget from resource_files (Android-style) to the
  resources attribute, which is the correct kt_jvm_library attribute for
  JVM classpath resources such as service-loader registrations.

## Issues Fixed